### PR TITLE
Add retention profiling, fix report accuracy, reframe real ceiling

### DIFF
--- a/OUTBOX-REPORT.md
+++ b/OUTBOX-REPORT.md
@@ -576,7 +576,7 @@ ILP, Streaming Coverage, and Spectral Clustering frequently hit the theoretical 
 
 **Why recall degrades with time window:** Relay retention policies are the binding constraint. Most relays prune old events to manage storage — popular high-volume relays prune more aggressively because they receive more data. A greedy algorithm that concentrates on these popular relays sees 93% recall at 7 days but 16% at 1 year: the relays it selected had the events last week, but deleted them months ago. Stochastic algorithms discover smaller relays that retain history longer because they receive less volume. This is why randomness in relay selection isn't noise — it's an archival strategy.
 
-Event recall across time windows (fiatjaf, testable-reliable authors). Events per (relay, author) pair capped at 10,000 — this prevents a single prolific relay from dominating the baseline count and biasing recall percentages toward whichever algorithm happens to select that relay.
+Event recall across time windows (fiatjaf single-profile, testable-reliable authors). For 6-profile mean validation, see cross-profile section. Events per (relay, author) pair capped at 10,000 — this prevents a single prolific relay from dominating the baseline count and biasing recall percentages toward whichever algorithm happens to select that relay.
 
 **Practitioner algorithms** (deployed or deployable in real clients):
 
@@ -835,7 +835,7 @@ A small fraction of prolific authors produce the majority of events. This power-
 
 3. **Greedy Set-Cover degrades sharply.** 84% at 7d → 16% at 1 year (6-profile means). It minimizes connections by concentrating on popular relays, but those relays don't necessarily retain old events. Algorithms that spread queries fare better long-term.
 
-4. **Aggregator results are surprisingly poor.** Primal achieves only 28.3% recall at 7 days and 0.9% at 3 years — worse than Popular+Random (damus + nos.lol + 2 random relays) at every window. This is unexpected for a relay that proxies many upstream relays, and may indicate a benchmark methodology limitation rather than a definitive conclusion about aggregators.
+4. **Aggregator results are surprisingly poor.** Primal achieves only 31.6% recall at 7 days (6-profile mean) and 0.9% at 3 years (fiatjaf single-profile) — worse than Popular+Random (damus + nos.lol + 2 random relays) at every window. This is unexpected for a relay that proxies many upstream relays, and may indicate a benchmark methodology limitation rather than a definitive conclusion about aggregators.
 
 5. **Author recall is more stable than event recall.** You can *find* most authors even at long windows (74-81% author recall at 1 year), but you miss most of their posts. The disparity means relay retention policies are the binding constraint, not relay selection.
 
@@ -864,7 +864,7 @@ Based on patterns observed across all implementations and benchmark results:
 
 8. **Support NIP-17 DM relays.** Only 4 of 10 mature implementations fully route DMs via kind 10050 relays. Kind 10050 is straightforward to implement and provides meaningful privacy benefits for direct messaging.
 
-9. **Aggregator results are surprisingly poor.** Primal reaches 28% recall at 7d and <1% at 3yr — worse than Popular+Random (damus + nos.lol + 2 random relays) at every window. This is unexpected: an aggregator that proxies tens if not hundreds of relays should in theory outperform 4 random connections. This may indicate a limitation in the benchmark methodology rather than a real-world indictment of aggregators.
+9. **Aggregator results are surprisingly poor.** Primal reaches 32% recall at 7d (6-profile mean) and <1% at 3yr — worse than Popular+Random (damus + nos.lol + 2 random relays) at every window. This is unexpected: an aggregator that proxies tens if not hundreds of relays should in theory outperform 4 random connections. This may indicate a limitation in the benchmark methodology rather than a real-world indictment of aggregators.
 
 ---
 

--- a/bench/deno.json
+++ b/bench/deno.json
@@ -1,7 +1,8 @@
 {
   "tasks": {
     "bench": "deno run --allow-net --allow-read --allow-write main.ts",
-    "check": "deno check main.ts"
+    "check": "deno check main.ts",
+    "retention": "deno run --allow-read retention-profile.ts"
   },
   "imports": {
     "@nostr/tools/": "jsr:@nostr/tools@^2.23/",

--- a/bench/deno.lock
+++ b/bench/deno.lock
@@ -3,6 +3,10 @@
   "specifiers": {
     "jsr:@nostr/tools@^2.23.1": "2.23.1",
     "jsr:@std/cli@1": "1.0.27",
+    "jsr:@std/fs@1": "1.0.23",
+    "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/path@^1.1.4": "1.1.4",
     "npm:@noble/ciphers@2.1.1": "2.1.1",
     "npm:@noble/curves@2.0.1": "2.0.1",
     "npm:@noble/hashes@2.0.1": "2.0.1",
@@ -20,6 +24,22 @@
     },
     "@std/cli@1.0.27": {
       "integrity": "eba97edd0891871a7410e835dd94b3c260c709cca5983df2689c25a71fbe04de"
+    },
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
+      "dependencies": [
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.4"
+      ]
+    },
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
     }
   },
   "npm": {

--- a/bench/probe-historical-nip65.ts
+++ b/bench/probe-historical-nip65.ts
@@ -1,0 +1,244 @@
+/**
+ * Probe: Do relays return historical kind-10002 (NIP-65) events?
+ *
+ * Kind-10002 is a replaceable event (kind 10000-19999), so per NIP-01
+ * relays SHOULD only keep the latest. But some archive relays may keep
+ * older versions. This script checks.
+ *
+ * If relays only return 1 event per author, historical NIP-65 walk-back
+ * is dead on arrival — the old relay lists are gone.
+ *
+ * Usage: deno run --allow-net --allow-read bench/probe-historical-nip65.ts
+ */
+
+import { dirname, fromFileUrl, join } from "jsr:@std/path@^1";
+import { expandGlob } from "jsr:@std/fs@^1/expand-glob";
+
+const SCRIPT_DIR = dirname(fromFileUrl(import.meta.url));
+const CACHE_DIR = join(SCRIPT_DIR, ".cache");
+
+// Relays to probe — mix of indexers, archives, and major relays
+const PROBE_RELAYS = [
+  "wss://purplepag.es",
+  "wss://relay.damus.io",
+  "wss://nos.lol",
+  "wss://nostr-pub.wellorder.net",
+  "wss://relay.primal.net",
+  "wss://nostr.wine",
+];
+
+const SAMPLE_SIZE = 50;
+const EOSE_TIMEOUT_MS = 10_000;
+const CONNECT_TIMEOUT_MS = 8_000;
+
+interface NostrEvent {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: string[][];
+}
+
+// --- load sample pubkeys from cache ---
+
+async function loadSamplePubkeys(): Promise<string[]> {
+  const all: string[] = [];
+  for await (const entry of expandGlob(join(CACHE_DIR, "phase2_*_31536000_*.json"))) {
+    const raw = await Deno.readTextFile(entry.path);
+    const data = JSON.parse(raw);
+    for (const b of data.baselines) {
+      if (b.classification === "testable-reliable") {
+        all.push(b.pubkey);
+      }
+    }
+  }
+  // Dedupe and sample
+  const unique = [...new Set(all)];
+  const step = Math.max(1, Math.floor(unique.length / SAMPLE_SIZE));
+  const sample: string[] = [];
+  for (let i = 0; i < unique.length && sample.length < SAMPLE_SIZE; i += step) {
+    sample.push(unique[i]);
+  }
+  return sample;
+}
+
+// --- minimal websocket client ---
+
+function queryRelay(
+  url: string,
+  pubkeys: string[],
+): Promise<{ relay: string; events: NostrEvent[]; error?: string }> {
+  return new Promise((resolve) => {
+    const events: NostrEvent[] = [];
+    const subId = "probe-hist";
+
+    const connectTimeout = setTimeout(() => {
+      resolve({ relay: url, events, error: "connect timeout" });
+    }, CONNECT_TIMEOUT_MS);
+
+    try {
+      const ws = new WebSocket(url);
+
+      ws.onopen = () => {
+        clearTimeout(connectTimeout);
+        ws.send(JSON.stringify(["REQ", subId, { kinds: [10002], authors: pubkeys }]));
+
+        setTimeout(() => {
+          try { ws.close(); } catch { /* ignore */ }
+          resolve({ relay: url, events });
+        }, EOSE_TIMEOUT_MS);
+      };
+
+      ws.onmessage = (msg: MessageEvent) => {
+        try {
+          const data = JSON.parse(msg.data);
+          if (Array.isArray(data)) {
+            if (data[0] === "EVENT" && data[1] === subId && data[2]) {
+              events.push(data[2] as NostrEvent);
+            }
+            if (data[0] === "EOSE" && data[1] === subId) {
+              try { ws.close(); } catch { /* ignore */ }
+              resolve({ relay: url, events });
+            }
+          }
+        } catch { /* ignore parse errors */ }
+      };
+
+      ws.onerror = () => {
+        clearTimeout(connectTimeout);
+        resolve({ relay: url, events, error: "websocket error" });
+      };
+
+      ws.onclose = () => {
+        clearTimeout(connectTimeout);
+        resolve({ relay: url, events });
+      };
+    } catch (err) {
+      clearTimeout(connectTimeout);
+      resolve({ relay: url, events, error: String(err) });
+    }
+  });
+}
+
+// --- main ---
+
+async function main() {
+  console.error("Loading sample pubkeys from cache...");
+  const pubkeys = await loadSamplePubkeys();
+  console.error(`Sampled ${pubkeys.length} testable-reliable authors\n`);
+
+  console.error(`Probing ${PROBE_RELAYS.length} relays for historical kind-10002 events...\n`);
+
+  const results = await Promise.all(
+    PROBE_RELAYS.map((url) => queryRelay(url, pubkeys)),
+  );
+
+  // Analyse
+  const pad = (s: string, n: number) => s.padEnd(n);
+
+  console.log(pad("Relay", 36) + "  events  authors  multi  max-span-days  example");
+  console.log("-".repeat(105));
+
+  for (const r of results) {
+    if (r.error) {
+      console.log(`${pad(r.relay, 36)}  ERROR: ${r.error}`);
+      continue;
+    }
+
+    const byPubkey = new Map<string, NostrEvent[]>();
+    for (const e of r.events) {
+      const list = byPubkey.get(e.pubkey) ?? [];
+      list.push(e);
+      byPubkey.set(e.pubkey, list);
+    }
+
+    let multiCount = 0;
+    let maxSpanDays = 0;
+    let exampleAuthor = "";
+    let exampleEventCount = 0;
+
+    for (const [pk, events] of byPubkey) {
+      if (events.length > 1) {
+        multiCount++;
+        events.sort((a, b) => a.created_at - b.created_at);
+        const span = Math.floor((events[events.length - 1].created_at - events[0].created_at) / 86400);
+        if (span > maxSpanDays) {
+          maxSpanDays = span;
+          exampleAuthor = pk.slice(0, 12) + "...";
+          exampleEventCount = events.length;
+        }
+      }
+    }
+
+    const maxStr = multiCount > 0 ? String(maxSpanDays) : "-";
+    const exStr = multiCount > 0 ? `${exampleAuthor} (${exampleEventCount} evts)` : "-";
+
+    console.log(
+      `${pad(r.relay, 36)}  ${String(r.events.length).padStart(6)}  ${String(byPubkey.size).padStart(7)}  ${String(multiCount).padStart(5)}  ${maxStr.padStart(13)}  ${exStr}`
+    );
+  }
+
+  // Deep dive: show relay-list churn for authors with multiple events on purplepag.es
+  const purp = results.find((r) => r.relay === "wss://purplepag.es");
+  if (purp && !purp.error) {
+    const byPk = new Map<string, NostrEvent[]>();
+    for (const e of purp.events) {
+      const list = byPk.get(e.pubkey) ?? [];
+      list.push(e);
+      byPk.set(e.pubkey, list);
+    }
+
+    const churners = [...byPk.entries()]
+      .filter(([, evts]) => evts.length > 1)
+      .sort((a, b) => b[1].length - a[1].length);
+
+    if (churners.length > 0) {
+      console.log("\n--- Relay list churn detail (purplepag.es) ---\n");
+      for (const [pk, events] of churners.slice(0, 5)) {
+        events.sort((a, b) => a.created_at - b.created_at);
+        console.log(`Author ${pk.slice(0, 16)}... (${events.length} versions):`);
+
+        // Extract write relays from each version
+        let prevRelays = new Set<string>();
+        for (const e of events) {
+          const writeRelays = new Set<string>();
+          for (const tag of e.tags) {
+            if (tag[0] === "r" && tag[1]) {
+              const marker = tag[2]?.toLowerCase();
+              if (!marker || marker === "write") writeRelays.add(tag[1]);
+            }
+          }
+          const date = new Date(e.created_at * 1000).toISOString().slice(0, 10);
+          const added = [...writeRelays].filter((r) => !prevRelays.has(r));
+          const removed = [...prevRelays].filter((r) => !writeRelays.has(r));
+          console.log(`  ${date}: ${writeRelays.size} write relays` +
+            (added.length > 0 ? `  +${added.length} added` : "") +
+            (removed.length > 0 ? `  -${removed.length} removed` : ""));
+          if (added.length > 0 && added.length <= 3) console.log(`    added: ${added.join(", ")}`);
+          if (removed.length > 0 && removed.length <= 3) console.log(`    removed: ${removed.join(", ")}`);
+          prevRelays = writeRelays;
+        }
+        console.log();
+      }
+    }
+  }
+
+  // Verdict
+  console.log("--- Verdict ---\n");
+  const relaysWithMulti = results.filter((r) => {
+    const byPk = new Map<string, number>();
+    for (const e of r.events) byPk.set(e.pubkey, (byPk.get(e.pubkey) ?? 0) + 1);
+    return [...byPk.values()].some((c) => c > 1);
+  });
+
+  if (relaysWithMulti.length === 0) {
+    console.log("No relay returned multiple kind-10002 events per author.");
+    console.log("Historical NIP-65 walk-back is NOT feasible — old relay lists are gone.");
+  } else {
+    console.log(`${relaysWithMulti.length}/${PROBE_RELAYS.length} relays returned historical kind-10002.`);
+    console.log(`But kind-10002 is replaceable per NIP-01 — most relays correctly discard old versions.`);
+    console.log(`Historical walk-back would need a dedicated archive, not standard relays.`);
+  }
+}
+
+main();

--- a/bench/retention-profile.ts
+++ b/bench/retention-profile.ts
@@ -1,0 +1,207 @@
+/**
+ * Relay Event Availability by Time Depth (outbox-b5v)
+ *
+ * Analyses cached phase2 data to show how event availability drops
+ * across time windows per relay. Zero network — reads only from cache.
+ *
+ * Usage: deno run --allow-read bench/retention-profile.ts [--min-authors N] [--json]
+ */
+
+import { expandGlob } from "jsr:@std/fs@^1/expand-glob";
+import { parseArgs } from "jsr:@std/cli@^1/parse-args";
+import { dirname, fromFileUrl, join } from "jsr:@std/path@^1";
+
+// --- types matching phase2 cache schema ---
+
+interface Baseline {
+  pubkey: string;
+  classification: string;
+  relaysSucceeded: string[];
+  relaysWithEvents: string[];
+}
+
+interface Phase2Cache {
+  pubkey: string;
+  windowSeconds: number;
+  followCount: number;
+  relayCount: number;
+  baselines: Baseline[];
+}
+
+// --- config ---
+
+const DISPLAY_WINDOWS = [604800, 31536000, 94608000]; // 7d, 1yr, 3yr
+
+// --- accumulation ---
+
+// key: `${relay}\t${window}`
+const withEventsCount = new Map<string, number>();
+const testableCount = new Map<string, number>();
+
+function key(relay: string, window: number): string {
+  return `${relay}\t${window}`;
+}
+
+function inc(map: Map<string, number>, k: string): void {
+  map.set(k, (map.get(k) ?? 0) + 1);
+}
+
+// --- pick best file per (profile, window) ---
+
+interface FileInfo {
+  path: string;
+  profile: string;
+  window: number;
+  relayCount: number;
+}
+
+const SCRIPT_DIR = dirname(fromFileUrl(import.meta.url));
+const CACHE_DIR = join(SCRIPT_DIR, ".cache");
+
+async function pickBestFiles(): Promise<FileInfo[]> {
+  const all: FileInfo[] = [];
+  for await (const entry of expandGlob(join(CACHE_DIR, "phase2_*.json"))) {
+    const parts = entry.name.replace(".json", "").split("_");
+    // phase2_{profile}_{window}_{follows}_{relays}
+    all.push({
+      path: entry.path,
+      profile: parts[1],
+      window: Number(parts[2]),
+      relayCount: Number(parts[4]),
+    });
+  }
+
+  // Group by (profile, window), keep file with most relays
+  const best = new Map<string, FileInfo>();
+  for (const f of all) {
+    const k = `${f.profile}_${f.window}`;
+    const existing = best.get(k);
+    if (!existing || f.relayCount > existing.relayCount) {
+      best.set(k, f);
+    }
+  }
+  return [...best.values()];
+}
+
+// --- main ---
+
+async function main() {
+  const args = parseArgs(Deno.args, {
+    default: { "min-authors": 3, json: false },
+    boolean: ["json"],
+    string: ["min-authors"],
+  });
+  const minAuthors = Number(args["min-authors"]);
+  const jsonOutput = args.json;
+
+  const files = await pickBestFiles();
+  if (files.length === 0) {
+    console.error(`No phase2 cache files found in ${CACHE_DIR}`);
+    Deno.exit(1);
+  }
+
+  // Process each file
+  for (const file of files) {
+    const raw = await Deno.readTextFile(file.path);
+    const data: Phase2Cache = JSON.parse(raw);
+
+    for (const b of data.baselines) {
+      if (b.classification !== "testable-reliable") continue;
+
+      for (const relay of b.relaysWithEvents) {
+        inc(withEventsCount, key(relay, data.windowSeconds));
+      }
+      for (const relay of b.relaysSucceeded) {
+        inc(testableCount, key(relay, data.windowSeconds));
+      }
+    }
+  }
+
+  // Collect all relays
+  const allRelays = new Set<string>();
+  for (const k of testableCount.keys()) {
+    allRelays.add(k.split("\t")[0]);
+  }
+
+  // Build rows
+  type Row = {
+    relay: string;
+    windows: Record<number, { withEvents: number; testable: number; rate: number }>;
+    authors: number; // max testable across windows
+    dropOff: number;
+  };
+
+  const rows: Row[] = [];
+  for (const relay of allRelays) {
+    const windows: Row["windows"] = {};
+    let maxTestable = 0;
+
+    for (const w of DISPLAY_WINDOWS) {
+      const we = withEventsCount.get(key(relay, w)) ?? 0;
+      const t = testableCount.get(key(relay, w)) ?? 0;
+      windows[w] = { withEvents: we, testable: t, rate: t > 0 ? we / t : 0 };
+      if (t > maxTestable) maxTestable = t;
+    }
+
+    if (maxTestable < minAuthors) continue;
+
+    const rates = DISPLAY_WINDOWS.map((w) => windows[w].rate).filter((r) => r > 0);
+    const dropOff = rates.length >= 2 ? 1 - Math.min(...rates) / Math.max(...rates) : 0;
+
+    rows.push({ relay, windows, authors: maxTestable, dropOff });
+  }
+
+  // Sort by 1yr availability descending
+  rows.sort((a, b) => (b.windows[31536000]?.rate ?? 0) - (a.windows[31536000]?.rate ?? 0));
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  // --- print table ---
+  const pad = (s: string, n: number) => s.padEnd(n);
+  const pct = (r: number) => r > 0 ? `${(r * 100).toFixed(0)}%`.padStart(5) : "   - ";
+
+  const hdr = `${pad("Relay", 40)}  ${pad("7d", 5)}  ${pad("1yr", 5)}  ${pad("3yr", 5)}  ${pad("drop", 5)}  authors`;
+  console.log(hdr);
+  console.log("-".repeat(hdr.length));
+
+  for (const row of rows) {
+    const cols = DISPLAY_WINDOWS.map((w) => pct(row.windows[w].rate));
+    const drop = pct(row.dropOff);
+    const relay = row.relay.length > 39 ? row.relay.slice(0, 36) + "..." : row.relay;
+    console.log(
+      `${pad(relay, 40)}  ${cols[0]}  ${cols[1]}  ${cols[2]}  ${drop}  ${String(row.authors).padStart(5)}`
+    );
+  }
+
+  // --- summary ---
+  console.log();
+  const relaysWithOneYr = rows.filter((r) => r.windows[31536000]?.rate > 0.5);
+  console.log(
+    `Relays with >50% availability at 1yr: ${relaysWithOneYr.length} of ${rows.length}`
+  );
+
+  const oneYrRates = rows
+    .map((r) => r.windows[31536000]?.rate ?? 0)
+    .filter((r) => r > 0)
+    .sort((a, b) => a - b);
+  if (oneYrRates.length > 0) {
+    const mid = Math.floor(oneYrRates.length / 2);
+    const median =
+      oneYrRates.length % 2 === 1
+        ? oneYrRates[mid]
+        : (oneYrRates[mid - 1] + oneYrRates[mid]) / 2;
+    console.log(`Median 1yr availability: ${(median * 100).toFixed(0)}%`);
+  }
+
+  console.log();
+  const significant = rows.filter((r) => r.authors >= 20);
+  console.log(`Top 10 relays by 1yr availability (≥20 authors):`);
+  for (const row of significant.slice(0, 10)) {
+    console.log(`  ${row.relay}  ${pct(row.windows[31536000].rate).trim()}  (${row.authors} authors)`);
+  }
+}
+
+main();

--- a/bench/src/algorithms/big-relays.ts
+++ b/bench/src/algorithms/big-relays.ts
@@ -13,9 +13,7 @@ import type {
  */
 const BIG_RELAY_URLS = [
   "wss://relay.damus.io",
-  "wss://relay.damus.io/",
   "wss://nos.lol",
-  "wss://nos.lol/",
 ];
 
 export function bigRelaysBaseline(

--- a/bench/src/algorithms/mod.ts
+++ b/bench/src/algorithms/mod.ts
@@ -193,7 +193,7 @@ export const ALGORITHM_REGISTRY: AlgorithmEntry[] = [
     id: "big-relays",
     name: "Big Relays (damus+nos.lol)",
     fn: bigRelaysBaseline,
-    nativeCap: true,
+    nativeCap: false,
     stochastic: false,
     defaults: {},
   },


### PR DESCRIPTION
## Summary

- **Retention profiling** (`bench/retention-profile.ts`): measures event availability across 277 relays at 7d/1yr/3yr. Key finding: relay retention (77% median at 1yr) explains only ~1/4 of the recall collapse — historical relay discovery is the dominant factor. Adds `deno task retention` CLI (zero network, reads from cache).
- **Historical NIP-65 probe** (`bench/probe-historical-nip65.ts`): confirms kind-10002 walk-back is infeasible (replaceable events discarded by all 6 probed relays).
- **Report fixes**: clarify single-profile vs cross-profile data, fix Primal recall to 6-profile mean (31.6%), clarify step 2 is alternative to step 1.
- **README update**: retitle section 4 from "NIP-65 adoption is the real ceiling" to "relay history is the real ceiling", link to #21.
- **Code fixes**: remove redundant URL variants in big-relays, fix `nativeCap` flag, normalize candidates in NIP-66 filter, parallelize monitor fetches.

## Test plan

- [ ] `deno check bench/retention-profile.ts` — type-checks clean
- [ ] `deno task retention` — produces table from cached data, zero network
- [ ] `deno check bench/probe-historical-nip65.ts` — type-checks clean
- [ ] `deno check examples/nip66-relay-filter.ts` — type-checks clean
- [ ] Review report/README text changes for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added analysis tools to profile relay event retention and probe historical relay data availability.

* **Documentation**
  * Updated architecture documentation with refined relay scenario descriptions and relay selection guidance.

* **Bug Fixes**
  * Improved relay URL normalization and filtering accuracy.

* **Configuration**
  * Added new benchmark tasks for retention profiling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->