### PR TITLE
Add FD+Thompson: Filter Decomposition with Thompson Sampling

### DIFF
--- a/IMPLEMENTATION-GUIDE.md
+++ b/IMPLEMENTATION-GUIDE.md
@@ -17,9 +17,11 @@ What's your starting point?
 │  └─ Simplicity over optimization? → Direct Mapping (30% 1yr, unlimited connections)
 │
 ├─ Historical event recall (archival, search)?
-│  ├─ Can persist state across sessions? → Welshman+Thompson Sampling (81% 1yr)
-│  └─ Stateless?                         → Filter Decomposition (25% 1yr) or
-│                                          Weighted Stochastic / Welshman (24% 1yr)
+│  ├─ Can persist state across sessions?
+│  │  ├─ Using Welshman/Coracle?  → Welshman+Thompson Sampling (81% 1yr)
+│  │  └─ Using rust-nostr?        → FD+Thompson (32% 1yr single-session)
+│  └─ Stateless?                  → Filter Decomposition (25% 1yr) or
+│                                   Weighted Stochastic / Welshman (24% 1yr)
 │
 └─ Anti-centralization (distribute relay load)?
    ├─ Via scoring?       → Weighted Stochastic (log dampening + random)
@@ -66,6 +68,13 @@ upgrade preserves randomness, adds memory, and is ~80 lines of code on top
 of what Coracle already ships.
 
 See [README.md § Thompson Sampling](README.md#thompson-sampling) for complete code including the full integration loop (startup → score → select → observe → persist).
+
+**For rust-nostr / Filter Decomposition users:** FD+Thompson is a variant that fits
+Filter Decomposition's per-author structure directly. It replaces lexicographic relay
+ordering with `sampleBeta(α, β)` scoring — no popularity weight. At 1yr (single session,
+cap@20), FD+Thompson achieves 29-39% event recall vs Filter Decomposition's 14-33%
+across 4 profiles. See [README.md § FD+Thompson](README.md#fdthompson-for-rust-nostr)
+for code.
 
 ### 2. Pre-filter relays with NIP-66
 

--- a/IMPLEMENTATION-GUIDE.md
+++ b/IMPLEMENTATION-GUIDE.md
@@ -18,8 +18,8 @@ What's your starting point?
 │
 ├─ Historical event recall (archival, search)?
 │  ├─ Can persist state across sessions?
-│  │  ├─ Using Welshman/Coracle?  → Welshman+Thompson Sampling (81% 1yr)
-│  │  └─ Using rust-nostr?        → FD+Thompson (32% 1yr single-session)
+│  │  ├─ Using Welshman/Coracle?  → Welshman+Thompson Sampling (89% 1yr)
+│  │  └─ Using rust-nostr?        → FD+Thompson (84% 1yr after 5 sessions)
 │  └─ Stateless?                  → Filter Decomposition (25% 1yr) or
 │                                   Weighted Stochastic / Welshman (24% 1yr)
 │
@@ -71,10 +71,11 @@ See [README.md § Thompson Sampling](README.md#thompson-sampling) for complete c
 
 **For rust-nostr / Filter Decomposition users:** FD+Thompson is a variant that fits
 Filter Decomposition's per-author structure directly. It replaces lexicographic relay
-ordering with `sampleBeta(α, β)` scoring — no popularity weight. At 1yr (single session,
-cap@20), FD+Thompson averages 31.8% event recall vs baseline FD's 23.1% — a **+38%
-relative improvement** (+8.7pp absolute) from a single session of learning across 4
-profiles. The gain is largest on small graphs (+53% relative for fiatjaf/194 follows).
+ordering with `sampleBeta(α, β)` scoring — no popularity weight. After 5 learning
+sessions (cap@20, NIP-66 filtered), FD+Thompson reaches **83.9% event recall** at 1yr
+vs baseline FD's 23.1% — converging within 2-3 sessions. Welshman+Thompson leads by
+~5pp (89.4%) due to the popularity weight, but FD+Thompson is a drop-in upgrade for
+existing rust-nostr code with no structural changes needed.
 See [README.md § FD+Thompson](README.md#fdthompson-for-rust-nostr) for code.
 
 ### 2. Pre-filter relays with NIP-66

--- a/OUTBOX-REPORT.md
+++ b/OUTBOX-REPORT.md
@@ -855,8 +855,8 @@ The algorithm is a direct upgrade path for rust-nostr: same per-author structure
 |---|:---:|:---:|:---:|:---:|
 | fiatjaf (194) | **39.0%** evt / **80.4%** auth | 37.0% / 78.6% | 25.5% / 72.5% | 24.7% / 72.5% |
 | Gato (399) | 20.6% / **89.5%** | **22.5%** / 87.4% | 13.1% / 78.4% | 14.5% / 75.5% |
-| ODELL (1,079) | 29.1% / 79.7% | **30.5%** / **82.7%** | 21.6% / 72.7% | 18.2% / 74.1% |
-| Telluride (2,747) | **38.6%** / 81.4% | **38.6%** / **84.2%** | 32.3% / 75.5% | 30.3% / 74.7% |
+| ODELL (1,779) | 29.1% / 79.7% | **30.5%** / **82.7%** | 21.6% / 72.7% | 18.2% / 74.1% |
+| Telluride (2,784) | **38.6%** / 81.4% | **38.6%** / **84.2%** | 32.3% / 75.5% | 30.3% / 74.7% |
 
 **Per-author median recall (1yr, cap@20):**
 
@@ -864,8 +864,8 @@ The algorithm is a direct upgrade path for rust-nostr: same per-author structure
 |---|:---:|:---:|:---:|:---:|
 | fiatjaf (194) | **39.4%** | 18.7% | 0.0% | 0.0% |
 | Gato (399) | 97.9% | **98.5%** | 87.5% | 83.3% |
-| ODELL (1,079) | 55.0% | **64.0%** | 35.0% | 17.0% |
-| Telluride (2,747) | 77.6% | **82.4%** | 60.6% | 52.0% |
+| ODELL (1,779) | 55.0% | **64.0%** | 35.0% | 17.0% |
+| Telluride (2,784) | 77.6% | **82.4%** | 60.6% | 52.0% |
 
 **Per-profile improvement over baseline Filter Decomposition (1yr event recall):**
 
@@ -873,15 +873,34 @@ The algorithm is a direct upgrade path for rust-nostr: same per-author structure
 |---|:---:|:---:|:---:|:---:|
 | fiatjaf (194) | 39.0% | 25.5% | +13.5pp | +53% |
 | Gato (399) | 20.6% | 13.1% | +7.5pp | +57% |
-| ODELL (1,079) | 29.1% | 21.6% | +7.5pp | +35% |
-| Telluride (2,747) | 38.6% | 32.3% | +6.3pp | +20% |
+| ODELL (1,779) | 29.1% | 21.6% | +7.5pp | +35% |
+| Telluride (2,784) | 38.6% | 32.3% | +6.3pp | +20% |
 | **4-profile mean** | **31.8%** | **23.1%** | **+8.7pp** | **+38%** |
+
+**5-session learning comparison (1yr event recall, cap@20, NIP-66 filtered, per-algorithm score DBs):**
+
+| Profile (follows) | FD+Thompson | Welshman+Thompson | Gap |
+|---|:---:|:---:|:---:|
+| fiatjaf (194) | 75.1% | 82.0% | -6.9pp |
+| Gato (399) | 91.9% | 95.5% | -3.6pp |
+| ODELL (1,779) | 85.3% | 90.5% | -5.2pp |
+| Telluride (2,784) | 83.4% | 89.5% | -6.1pp |
+| **4-profile mean** | **83.9%** | **89.4%** | **-5.5pp** |
+
+**FD+Thompson session progression (1yr event recall):**
+
+| Profile (follows) | S1 | S2 | S3 | S4 | S5 |
+|---|:---:|:---:|:---:|:---:|:---:|
+| fiatjaf (194) | 16.5% | 63.8% | 75.1% | 75.1% | 75.1% |
+| Gato (399) | 37.9% | 84.4% | 88.9% | 92.3% | 91.9% |
+| ODELL (1,779) | 17.5% | 59.1% | 77.5% | 80.3% | 85.3% |
+| Telluride (2,784) | 17.1% | 54.4% | 78.2% | 81.5% | 83.4% |
 
 **Key findings:**
 
-1. **Both Thompson variants far exceed their stateless baselines.** FD+Thompson averages 31.8% event recall vs Filter Decomposition's 23.1% at 1yr — a +38% relative improvement from a single session of learning. Welshman+Thompson averages ~32% vs Weighted Stochastic's ~22% (+45% relative). No multi-session convergence needed; the gain is immediate.
+1. **Both Thompson variants far exceed their stateless baselines.** FD+Thompson averages 31.8% event recall from a single session vs Filter Decomposition's 23.1% at 1yr — a +38% relative improvement. After 5 learning sessions, FD+Thompson reaches 83.9% (a 2.6× improvement over session 1). Welshman+Thompson reaches 89.4%. Most gains arrive in sessions 2-3; sessions 4-5 provide diminishing returns.
 
-2. **Welshman+Thompson wins at larger follow counts.** The `(1 + log(weight))` popularity factor helps at 1,000+ follows — the popularity signal correctly identifies relays where events are more likely to survive. FD+Thompson wins on fiatjaf's small graph where popularity bias over-concentrates on relays that prune old events.
+2. **Welshman+Thompson leads by 5-7pp at all profile sizes after convergence.** The `(1 + log(weight))` popularity factor provides a consistent advantage — the popularity signal helps identify relays that retain events across all follow-count scales, not just large graphs. The gap is narrowest on Gato (3.6pp) and widest on fiatjaf (6.9pp).
 
 3. **Median recall tells a different story.** FD+Thompson's 39.4% median on fiatjaf (vs 18.7% for Welshman+Thompson) shows more equitable per-author coverage — fewer authors with zero recall. At larger scales, Welshman+Thompson's median advantage (64% vs 55% on ODELL) reflects better overall delivery.
 
@@ -901,7 +920,7 @@ Based on patterns observed across all implementations and benchmark results:
 
 4. **Configure multiple indexer relays.** Relying on a single indexer (e.g., only purplepag.es) is a single point of failure. Amethyst's 5-indexer approach is the most resilient.
 
-5. **Handle misconfigured kind 10002.** At minimum, filter out known-bad relay entries. Blocklists for aggregator relays (feeds.nostr.band, filter.nostr.wine) and special-purpose relays prevent wasted connections.
+5. **Handle misconfigured kind 10002.** NIP-65 relay list pollution is a widespread problem: users put purplepages, NWC relays, blastrs, proxies, and read-only feed relays into their outbox relay list because clients only expose a single relay configuration. As [vitorpamplona notes](https://github.com/nostr-protocol/nips/pull/2243#issuecomment-2695456282): "NIP-65 lists are for everybody else to find your content or to send content to you (tagging). They are not the place to put any other relay that you are using in any client." At minimum, filter out known-bad relay entries. Blocklists for aggregator relays (feeds.nostr.band, filter.nostr.wine), special-purpose relays (purplepag.es, NWC endpoints), and blast/proxy relays prevent wasted connections on relays that have no user content.
 
 6. **Make outbox debuggable — but go beyond assignment coverage.** noStrudel's coverage debugger is the only client that exposes outbox internals (coverage %, orphaned users, per-relay assignment, color-coded health). But it only shows the academic view — the on-paper relay mapping. NIP-66 monitors check relay liveness, but no client verifies per-author delivery — "did this relay return events for author X?" Our central finding is that these two views diverge sharply (85% assignment coverage can mean 16% event recall at 1yr). True completeness isn't measurable (no relay has everything — if indexers were complete, you'd skip outbox entirely), but cross-checking catches systematic gaps: a relay that's supposed to serve an author but consistently returns nothing. Opportunities for future work: per-author delivery cross-checks against independent relays, relay response/efficiency rates (events delivered per connection), orphan root-cause analysis (missing kind 10002 vs relays offline vs filtered out), and relay list staleness indicators.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ All deployed client algorithms plus key experimental ones:
 | Algorithm | Used by | 1yr recall | 7d recall | Verdict |
 |---|---|:---:|:---:|---|
 | **Welshman+Thompson** | *not yet deployed* | 81% | 92% | Upgrade path for Coracle — learns from delivery |
-| **FD+Thompson** | *not yet deployed* | — | 97% | Upgrade path for rust-nostr — learns without popularity bias |
+| **FD+Thompson** | *not yet deployed* | 32% | 97% | Upgrade path for rust-nostr — +38% over baseline FD from learning |
 | **Filter Decomposition** | rust-nostr | 25% | 77% | Per-author top-N write relays; strong at long windows |
 | **Welshman Stochastic** | Coracle | 24% | 83% | Best stateless deployed algorithm for archival — 1.5× Greedy at 1yr |
 | **Greedy Set-Cover** | Gossip, Applesauce, Wisp | 16% | 84% | Best on-paper coverage; degrades sharply for history |
@@ -119,7 +119,7 @@ All deployed client algorithms plus key experimental ones:
 | Big Relays | 8% | 61% | Just damus+nos.lol — the "do nothing" baseline |
 | Primal Aggregator\*\*\* | 1% | 32% | Single caching relay — 100% assignment but low actual recall |
 
-*1yr and 7d recall: 6-profile means from cross-profile benchmarks (Section 8.2 of [OUTBOX-REPORT.md](OUTBOX-REPORT.md)). All testable-reliable authors, 20-connection cap except Direct Mapping. Thompson = 4-profile mean with NIP-66, 5 learning sessions. FD+Thompson 7d = 4-profile single-run mean. Stochastic algorithms have run-to-run variance of ±2–8pp depending on profile size (see [variance analysis](OUTBOX-REPORT.md#82-approximating-real-world-conditions-event-verification)).*
+*1yr and 7d recall: 6-profile means from cross-profile benchmarks (Section 8.2 of [OUTBOX-REPORT.md](OUTBOX-REPORT.md)). All testable-reliable authors, 20-connection cap except Direct Mapping. Thompson = 4-profile mean with NIP-66, 5 learning sessions. FD+Thompson = 4-profile single-run mean (32% 1yr vs baseline FD's 23% = +38% relative improvement from learning). Stochastic algorithms have run-to-run variance of ±2–8pp depending on profile size (see [variance analysis](OUTBOX-REPORT.md#82-approximating-real-world-conditions-event-verification)).*
 
 *\*\*Direct Mapping uses unlimited connections (all declared write relays, typically 50-200+). Its high recall reflects connection count, not algorithmic superiority.*
 
@@ -253,13 +253,15 @@ Same `sampleBeta()`, same stats table, same update loop as [Thompson Sampling ab
 
 **1yr cross-profile results (cap@20, single run):**
 
-| Profile (follows) | FD+Thompson | Welshman+Thompson | Filter Decomp |
-|---|---|---|---|
-| fiatjaf (194) | **39.0%** | 37.0% | 25.5% |
-| ODELL (1,079) | 29.1% | **30.5%** | 21.6% |
-| Telluride (2,747) | **38.6%** | **38.6%** | 32.3% |
+| Profile (follows) | FD+Thompson | Filter Decomp (baseline) | Gain |
+|---|:---:|:---:|:---:|
+| fiatjaf (194) | **39.0%** | 25.5% | +13.5pp (+53%) |
+| Gato (399) | **20.6%** | 13.1% | +7.5pp (+57%) |
+| ODELL (1,079) | **29.1%** | 21.6% | +7.5pp (+35%) |
+| Telluride (2,747) | **38.6%** | 32.3% | +6.3pp (+20%) |
+| **4-profile mean** | **31.8%** | **23.1%** | **+8.7pp (+38%)** |
 
-*FD+Thompson and Welshman+Thompson are competitive — FD+Thompson wins on small graphs where popularity bias hurts; Welshman+Thompson wins on larger graphs where the popularity signal helps navigate retention. Both far exceed stateless Filter Decomposition.*
+*FD+Thompson adds +8.7pp event recall on average from a single session of learning. The gain is largest on small graphs where lexicographic ordering wastes slots on pruning-heavy relays. Welshman+Thompson is competitive at larger follow counts where the popularity signal helps — see [Section 8.4](OUTBOX-REPORT.md#84-fdthompson-filter-decomposition-with-thompson-sampling) for the full comparison.*
 
 ### NIP-66 pre-filter
 
@@ -348,3 +350,5 @@ analysis/
 - [Benchmark Recreation](Benchmark-recreation.md) — Reproduce all results
 - [nostrability#69](https://github.com/niclas-pfeifer/nostrability/issues/69) — Parent issue
 - [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) — Relay List Metadata specification
+- [Building Nostr](https://building-nostr.coracle.social) — Protocol architecture guide (relay routing, content migration, bootstrapping)
+- [replicatr](https://github.com/coracle-social/replicatr) — Event replication daemon for relay list changes (negentropy sync)

--- a/analysis/clients/rust-nostr-voyage-nosotros-wisp-shopstr.md
+++ b/analysis/clients/rust-nostr-voyage-nosotros-wisp-shopstr.md
@@ -24,7 +24,7 @@ rust-nostr stores bitflags per (pubkey, relay) pair: READ, WRITE, PRIVATE_MESSAG
 - SQLite backend persists the gossip graph across restarts (received_events count, last_received_event timestamp).
 
 ### Upgrade Path: FD+Thompson
-rust-nostr's per-author Filter Decomposition can be upgraded to FD+Thompson by replacing lexicographic relay ordering with `sampleBeta(α, β)` scoring from delivery history. Same per-author structure, same write limits — just learned relay ranking instead of static. At 1yr (single session, cap@20): FD+Thompson averages 31.8% event recall vs baseline FD's 23.1% — a **+38% relative improvement** (+8.7pp absolute) across 4 profiles. The gain ranges from +20% (Telluride/2747 follows) to +57% (Gato/399 follows). See [README.md § FD+Thompson](../../README.md#fdthompson-for-rust-nostr) for implementation code.
+rust-nostr's per-author Filter Decomposition can be upgraded to FD+Thompson by replacing lexicographic relay ordering with `sampleBeta(α, β)` scoring from delivery history. Same per-author structure, same write limits — just learned relay ranking instead of static. After 5 learning sessions (cap@20, NIP-66 filtered): FD+Thompson reaches **83.9% event recall** at 1yr vs baseline FD's 23.1% — converging within 2-3 sessions. Welshman+Thompson leads by ~5pp (89.4%) due to popularity weighting, but FD+Thompson requires no structural changes to existing rust-nostr code. See [README.md § FD+Thompson](../../README.md#fdthompson-for-rust-nostr) for implementation code.
 
 ---
 

--- a/analysis/clients/rust-nostr-voyage-nosotros-wisp-shopstr.md
+++ b/analysis/clients/rust-nostr-voyage-nosotros-wisp-shopstr.md
@@ -23,6 +23,9 @@ rust-nostr stores bitflags per (pubkey, relay) pair: READ, WRITE, PRIVATE_MESSAG
 - Freshness checking via per-pubkey tokio semaphores, stress-tested to 10k concurrent requests.
 - SQLite backend persists the gossip graph across restarts (received_events count, last_received_event timestamp).
 
+### Upgrade Path: FD+Thompson
+rust-nostr's per-author Filter Decomposition can be upgraded to FD+Thompson by replacing lexicographic relay ordering with `sampleBeta(α, β)` scoring from delivery history. Same per-author structure, same write limits — just learned relay ranking instead of static. At 1yr (single session, cap@20): 29-39% event recall vs baseline Filter Decomposition's 14-33% across 4 profiles. See [README.md § FD+Thompson](../../README.md#fdthompson-for-rust-nostr) for implementation code.
+
 ---
 
 ## Voyage (Kotlin, Android)

--- a/analysis/clients/rust-nostr-voyage-nosotros-wisp-shopstr.md
+++ b/analysis/clients/rust-nostr-voyage-nosotros-wisp-shopstr.md
@@ -24,7 +24,7 @@ rust-nostr stores bitflags per (pubkey, relay) pair: READ, WRITE, PRIVATE_MESSAG
 - SQLite backend persists the gossip graph across restarts (received_events count, last_received_event timestamp).
 
 ### Upgrade Path: FD+Thompson
-rust-nostr's per-author Filter Decomposition can be upgraded to FD+Thompson by replacing lexicographic relay ordering with `sampleBeta(α, β)` scoring from delivery history. Same per-author structure, same write limits — just learned relay ranking instead of static. At 1yr (single session, cap@20): 29-39% event recall vs baseline Filter Decomposition's 14-33% across 4 profiles. See [README.md § FD+Thompson](../../README.md#fdthompson-for-rust-nostr) for implementation code.
+rust-nostr's per-author Filter Decomposition can be upgraded to FD+Thompson by replacing lexicographic relay ordering with `sampleBeta(α, β)` scoring from delivery history. Same per-author structure, same write limits — just learned relay ranking instead of static. At 1yr (single session, cap@20): FD+Thompson averages 31.8% event recall vs baseline FD's 23.1% — a **+38% relative improvement** (+8.7pp absolute) across 4 profiles. The gain ranges from +20% (Telluride/2747 follows) to +57% (Gato/399 follows). See [README.md § FD+Thompson](../../README.md#fdthompson-for-rust-nostr) for implementation code.
 
 ---
 

--- a/bench/deno.json
+++ b/bench/deno.json
@@ -2,7 +2,8 @@
   "tasks": {
     "bench": "deno run --allow-net --allow-read --allow-write main.ts",
     "check": "deno check main.ts",
-    "retention": "deno run --allow-read retention-profile.ts"
+    "retention": "deno run --allow-read retention-profile.ts",
+    "probe-hints": "deno run --allow-net --allow-read probe-relay-hints.ts"
   },
   "imports": {
     "@nostr/tools/": "jsr:@nostr/tools@^2.23/",

--- a/bench/deno.json
+++ b/bench/deno.json
@@ -3,7 +3,7 @@
     "bench": "deno run --allow-net --allow-read --allow-write main.ts",
     "check": "deno check main.ts",
     "retention": "deno run --allow-read retention-profile.ts",
-    "probe-hints": "deno run --allow-net --allow-read probe-relay-hints.ts"
+    "probe-nip11": "deno run --allow-net --allow-read --allow-write probe-nip11.ts"
   },
   "imports": {
     "@nostr/tools/": "jsr:@nostr/tools@^2.23/",

--- a/bench/probe-nip11.ts
+++ b/bench/probe-nip11.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env -S deno run --allow-net --allow-read --allow-write
+/**
+ * NIP-11 Relay Classification Probe
+ *
+ * Fetches NIP-11 info documents from all candidate relays in a user's
+ * outbox graph, classifies them, and prints a summary table.
+ *
+ * Usage: deno run --allow-net --allow-read --allow-write probe-nip11.ts <hex_pubkey>
+ */
+
+import { fetchBenchmarkInput } from "./src/fetch.ts";
+
+const CONCURRENCY = 15;
+const FETCH_TIMEOUT_MS = 5_000;
+
+type Category = "content" | "paid" | "auth-gated" | "restricted" | "no-nip11" | "offline";
+
+interface Nip11Result {
+  url: string;
+  category: Category;
+  name?: string;
+  description?: string;
+  raw?: Record<string, unknown>;
+}
+
+function wsToHttp(wsUrl: string): string {
+  return wsUrl.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+}
+
+function classify(doc: Record<string, unknown>): Category {
+  const limitation = doc.limitation as Record<string, unknown> | undefined;
+  if (limitation) {
+    if (limitation.payment_required === true) return "paid";
+    if (limitation.auth_required === true) return "auth-gated";
+    if (limitation.restricted_writes === true) return "restricted";
+  }
+  return "content";
+}
+
+async function probeRelay(url: string): Promise<Nip11Result> {
+  const httpUrl = wsToHttp(url);
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    const resp = await fetch(httpUrl, {
+      headers: { Accept: "application/nostr+json" },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+
+    if (!resp.ok) {
+      return { url, category: "no-nip11" };
+    }
+
+    const text = await resp.text();
+    let doc: Record<string, unknown>;
+    try {
+      doc = JSON.parse(text);
+    } catch {
+      return { url, category: "no-nip11" };
+    }
+
+    const category = classify(doc);
+    return {
+      url,
+      category,
+      name: typeof doc.name === "string" ? doc.name : undefined,
+      description: typeof doc.description === "string" ? doc.description : undefined,
+      raw: doc,
+    };
+  } catch {
+    return { url, category: "offline" };
+  }
+}
+
+async function probeAll(urls: string[]): Promise<Nip11Result[]> {
+  const results: Nip11Result[] = [];
+  const queue = [...urls];
+
+  async function worker() {
+    while (queue.length > 0) {
+      const url = queue.shift()!;
+      results.push(await probeRelay(url));
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(CONCURRENCY, urls.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+async function main() {
+  const hex = Deno.args[0];
+  if (!hex || !/^[a-f0-9]{64}$/.test(hex)) {
+    console.error("Usage: deno run ... probe-nip11.ts <64-char-hex-pubkey>");
+    Deno.exit(1);
+  }
+
+  const prefix = hex.slice(0, 12);
+
+  console.error(`Fetching relay data for ${prefix}...`);
+  const input = await fetchBenchmarkInput({ targetPubkey: hex, filterProfile: "strict" });
+
+  const candidateUrls = [...input.relayToWriters.keys()].sort();
+  console.error(`Found ${candidateUrls.length} candidate relays. Probing NIP-11...`);
+
+  const results = await probeAll(candidateUrls);
+
+  // Group by category
+  const grouped = new Map<Category, Nip11Result[]>();
+  for (const r of results) {
+    const list = grouped.get(r.category) ?? [];
+    list.push(r);
+    grouped.set(r.category, list);
+  }
+
+  const responded = results.filter((r) => r.category !== "no-nip11" && r.category !== "offline").length;
+  const notResponded = results.length - responded;
+
+  // Print summary
+  console.log(`\n## NIP-11 Relay Classification: ${prefix}`);
+  console.log(`\nCandidate relays: ${candidateUrls.length}`);
+  console.log(`Probed: ${results.length} (${responded} responded, ${notResponded} no NIP-11/offline)\n`);
+
+  const categories: Category[] = ["content", "paid", "auth-gated", "restricted", "no-nip11", "offline"];
+
+  console.log(`| Category       | Count | % of candidates | Example relays            |`);
+  console.log(`|----------------|-------|-----------------|---------------------------|`);
+  for (const cat of categories) {
+    const items = grouped.get(cat) ?? [];
+    const pct = candidateUrls.length > 0 ? ((items.length / candidateUrls.length) * 100).toFixed(1) : "0.0";
+    const examples = items
+      .slice(0, 3)
+      .map((r) => r.url.replace(/^wss:\/\//, ""))
+      .join(", ");
+    const padCat = cat.padEnd(14);
+    const padCount = String(items.length).padStart(5);
+    const padPct = `${pct}%`.padStart(15);
+    console.log(`| ${padCat} | ${padCount} | ${padPct} | ${examples.padEnd(25)} |`);
+  }
+
+  // Detail sections for non-content categories
+  for (const cat of ["paid", "auth-gated", "restricted"] as Category[]) {
+    const items = grouped.get(cat) ?? [];
+    if (items.length === 0) continue;
+    console.log(`\n### ${cat.charAt(0).toUpperCase() + cat.slice(1)} relays (${items.length})`);
+    for (const r of items) {
+      const desc = r.description ? ` — "${r.description.slice(0, 80)}"` : "";
+      console.log(`${r.url}${desc}`);
+    }
+  }
+
+  // Cache results
+  try {
+    await Deno.mkdir(".cache", { recursive: true });
+    const cacheData = {
+      pubkey: hex,
+      probedAt: new Date().toISOString(),
+      totalCandidates: candidateUrls.length,
+      results: results.map((r) => ({
+        url: r.url,
+        category: r.category,
+        name: r.name,
+        description: r.description,
+      })),
+    };
+    const cachePath = `.cache/nip11_probe_${prefix}.json`;
+    await Deno.writeTextFile(cachePath, JSON.stringify(cacheData, null, 2));
+    console.error(`\nResults cached to ${cachePath}`);
+  } catch (e) {
+    console.error(`Warning: could not write cache: ${e}`);
+  }
+}
+
+main();

--- a/bench/src/algorithms/beta.ts
+++ b/bench/src/algorithms/beta.ts
@@ -1,0 +1,65 @@
+/** Clamp rng() to avoid 0 (which breaks Math.log / Math.pow). */
+const EPS = Number.MIN_VALUE;
+function rngPos(rng: () => number): number {
+  return Math.max(rng(), EPS);
+}
+
+/**
+ * Sample from a Beta(alpha, beta) distribution using the Jöhnk algorithm.
+ * Returns a value in [0, 1].
+ */
+export function sampleBeta(alpha: number, beta: number, rng: () => number): number {
+  // For alpha=1, beta=1 (uniform prior), just return rng()
+  if (alpha === 1 && beta === 1) return rng();
+
+  // Jöhnk's algorithm for general alpha, beta
+  if (alpha < 1 && beta < 1) {
+    while (true) {
+      const u = rngPos(rng);
+      const v = rngPos(rng);
+      const x = Math.pow(u, 1 / alpha);
+      const y = Math.pow(v, 1 / beta);
+      if (x + y <= 1) {
+        if (x + y > 0) return x / (x + y);
+        // Handle underflow by taking logs
+        const logX = Math.log(u) / alpha;
+        const logY = Math.log(v) / beta;
+        const logM = logX > logY ? logX : logY;
+        return Math.exp(logX - logM) / (Math.exp(logX - logM) + Math.exp(logY - logM));
+      }
+    }
+  }
+
+  // For larger alpha/beta, use gamma sampling approach
+  const x = sampleGamma(alpha, rng);
+  const y = sampleGamma(beta, rng);
+  return x / (x + y);
+}
+
+/**
+ * Sample from a Gamma(shape, 1) distribution using Marsaglia and Tsang's method.
+ */
+function sampleGamma(shape: number, rng: () => number): number {
+  if (shape < 1) {
+    // Boost: Gamma(shape) = Gamma(shape+1) * U^(1/shape)
+    return sampleGamma(shape + 1, rng) * Math.pow(rngPos(rng), 1 / shape);
+  }
+
+  const d = shape - 1 / 3;
+  const c = 1 / Math.sqrt(9 * d);
+
+  while (true) {
+    let x: number;
+    let v: number;
+    do {
+      // Box-Muller for normal sample
+      x = Math.sqrt(-2 * Math.log(rngPos(rng))) * Math.cos(2 * Math.PI * rng());
+      v = 1 + c * x;
+    } while (v <= 0);
+
+    v = v * v * v;
+    const u = rng();
+    if (u < 1 - 0.0331 * (x * x) * (x * x)) return d * v;
+    if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v;
+  }
+}

--- a/bench/src/algorithms/beta.ts
+++ b/bench/src/algorithms/beta.ts
@@ -9,6 +9,15 @@ function rngPos(rng: () => number): number {
  * Returns a value in [0, 1].
  */
 export function sampleBeta(alpha: number, beta: number, rng: () => number): number {
+  if (
+    !Number.isFinite(alpha) || !Number.isFinite(beta) ||
+    alpha <= 0 || beta <= 0
+  ) {
+    throw new RangeError(
+      `sampleBeta requires alpha > 0 and beta > 0, got alpha=${alpha}, beta=${beta}`,
+    );
+  }
+
   // For alpha=1, beta=1 (uniform prior), just return rng()
   if (alpha === 1 && beta === 1) return rng();
 
@@ -40,6 +49,12 @@ export function sampleBeta(alpha: number, beta: number, rng: () => number): numb
  * Sample from a Gamma(shape, 1) distribution using Marsaglia and Tsang's method.
  */
 function sampleGamma(shape: number, rng: () => number): number {
+  if (!Number.isFinite(shape) || shape <= 0) {
+    throw new RangeError(
+      `sampleGamma requires shape > 0, got shape=${shape}`,
+    );
+  }
+
   if (shape < 1) {
     // Boost: Gamma(shape) = Gamma(shape+1) * U^(1/shape)
     return sampleGamma(shape + 1, rng) * Math.pow(rngPos(rng), 1 / shape);

--- a/bench/src/algorithms/mod.ts
+++ b/bench/src/algorithms/mod.ts
@@ -31,6 +31,7 @@ import { greedyEpsilon } from "./greedy-epsilon.ts";
 import { welshmanThompson } from "./welshman-thompson.ts";
 import { jumbleCoveragePruning } from "./jumble.ts";
 import { bigRelaysBaseline } from "./big-relays.ts";
+import { fdThompson } from "./fd-thompson.ts";
 
 export interface AlgorithmEntry {
   id: string;
@@ -188,6 +189,14 @@ export const ALGORITHM_REGISTRY: AlgorithmEntry[] = [
     nativeCap: false,
     stochastic: false,
     defaults: {},
+  },
+  {
+    id: "fd-thompson",
+    name: "FD+Thompson",
+    fn: fdThompson,
+    nativeCap: false,
+    stochastic: true,
+    defaults: { writeLimit: 3 },
   },
   {
     id: "big-relays",

--- a/bench/src/hint-enrichment.ts
+++ b/bench/src/hint-enrichment.ts
@@ -1,0 +1,169 @@
+import { connectToRelay, subscribeAndCollect, closeRelay } from "./fetch.ts";
+import { filterRelayUrl } from "./normalize.ts";
+import type { BenchmarkInput, Pubkey, RelayUrl } from "./types.ts";
+
+const HINT_BATCH_SIZE = 5;
+const MAX_HINTS_PER_AUTHOR = 5;
+
+/** pubkey → relay → mention count */
+export type HintMap = Map<Pubkey, Map<RelayUrl, number>>;
+
+interface HintEnrichmentStats {
+  relaysAdded: number;
+  authorsEnriched: number;
+  authorsEnrichedExisting: number;
+  authorsEnrichedHintOnly: number;
+}
+
+export interface HintEnrichmentResult extends HintEnrichmentStats {
+  hintMap: HintMap;
+}
+
+/**
+ * Sanitize a relay URL from a p-tag hint.
+ * Handles whitespace, trailing punctuation, and multi-protocol junk.
+ */
+function sanitizeHintUrl(raw: string): string | null {
+  // Take first whitespace-delimited token
+  const token = raw.trim().split(/\s/)[0];
+  if (!token) return null;
+  // Strip trailing commas/semicolons
+  const cleaned = token.replace(/[,;]+$/, "");
+  if (!cleaned) return null;
+  // Reject if multiple :// (garbled URLs)
+  const protoMatches = cleaned.match(/:\/\//g);
+  if (protoMatches && protoMatches.length > 1) return null;
+  return cleaned;
+}
+
+export async function enrichWithRelayHints(
+  input: BenchmarkInput,
+  indexerRelays: string[],
+): Promise<HintEnrichmentResult> {
+  const followsSet = new Set(input.follows);
+  const authors = [...input.follows];
+
+  // Connect to indexer relays
+  const conns = [];
+  for (const url of indexerRelays) {
+    const conn = await connectToRelay(url);
+    if (conn.ws && conn.ws.readyState === WebSocket.OPEN) {
+      conns.push(conn);
+    } else {
+      closeRelay(conn);
+    }
+  }
+
+  if (conns.length === 0) {
+    console.log("[hints] Failed to connect to any indexer relay");
+    return { relaysAdded: 0, authorsEnriched: 0, authorsEnrichedExisting: 0, authorsEnrichedHintOnly: 0, hintMap: new Map() };
+  }
+
+  console.log(`[hints] Connected to ${conns.length}/${indexerRelays.length} indexer relays`);
+
+  // Fetch kind-1 events in batches and extract p-tag hints
+  // hintedPubkey → relay → count
+  const hintCounts = new Map<Pubkey, Map<RelayUrl, number>>();
+  const seenEventIds = new Set<string>();
+
+  for (let i = 0; i < authors.length; i += HINT_BATCH_SIZE) {
+    const batch = authors.slice(i, i + HINT_BATCH_SIZE);
+    const subId = `hints-${i}`;
+
+    const batchEvents = await Promise.all(
+      conns.map((conn) =>
+        subscribeAndCollect(conn, subId, {
+          kinds: [1],
+          authors: batch,
+          limit: 200,
+        })
+      ),
+    );
+
+    for (const events of batchEvents) {
+      for (const event of events) {
+        if (seenEventIds.has(event.id)) continue;
+        seenEventIds.add(event.id);
+
+        for (const tag of event.tags) {
+          if (tag[0] !== "p" || !tag[1] || !tag[2]) continue;
+          const hintedPubkey = tag[1];
+          if (!followsSet.has(hintedPubkey)) continue;
+
+          const sanitized = sanitizeHintUrl(tag[2]);
+          if (!sanitized) continue;
+
+          const filterResult = filterRelayUrl(sanitized, input.fetchMeta.filterProfile);
+          if (!filterResult.accepted) continue;
+
+          const relayUrl = filterResult.url;
+          let relayCounts = hintCounts.get(hintedPubkey);
+          if (!relayCounts) {
+            relayCounts = new Map();
+            hintCounts.set(hintedPubkey, relayCounts);
+          }
+          relayCounts.set(relayUrl, (relayCounts.get(relayUrl) ?? 0) + 1);
+        }
+      }
+    }
+
+    if (i + HINT_BATCH_SIZE < authors.length && (i / HINT_BATCH_SIZE) % 20 === 0) {
+      console.log(`[hints] Scanned ${Math.min(i + HINT_BATCH_SIZE, authors.length)}/${authors.length} authors`);
+    }
+  }
+
+  // Close connections
+  for (const conn of conns) closeRelay(conn);
+
+  // Apply top-N hints to maps
+  let relaysAdded = 0;
+  let authorsEnrichedExisting = 0;
+  let authorsEnrichedHintOnly = 0;
+
+  for (const [pubkey, relayCounts] of hintCounts) {
+    const existingRelays = input.writerToRelays.get(pubkey);
+    const existingSet = existingRelays ?? new Set<RelayUrl>();
+
+    // Sort by count descending, take top N not already in set
+    const candidates = [...relayCounts.entries()]
+      .filter(([url]) => !existingSet.has(url))
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, MAX_HINTS_PER_AUTHOR);
+
+    if (candidates.length === 0) continue;
+
+    const hadExisting = existingRelays !== undefined && existingRelays.size > 0;
+
+    if (!existingRelays) {
+      input.writerToRelays.set(pubkey, new Set());
+    }
+    const pubRelays = input.writerToRelays.get(pubkey)!;
+
+    for (const [relayUrl] of candidates) {
+      pubRelays.add(relayUrl);
+      const writers = input.relayToWriters.get(relayUrl) ?? new Set<Pubkey>();
+      writers.add(pubkey);
+      input.relayToWriters.set(relayUrl, writers);
+      relaysAdded++;
+    }
+
+    if (hadExisting) {
+      authorsEnrichedExisting++;
+    } else {
+      authorsEnrichedHintOnly++;
+    }
+  }
+
+  const authorsEnriched = authorsEnrichedExisting + authorsEnrichedHintOnly;
+  const authorsWithZeroHints = input.follows.length - hintCounts.size;
+
+  console.log(`\n=== Relay Hint Enrichment ===`);
+  console.log(`Events scanned: ${seenEventIds.size}`);
+  console.log(`Follows with hints: ${hintCounts.size}/${input.follows.length}`);
+  console.log(`  Enriched (had NIP-65): ${authorsEnrichedExisting}`);
+  console.log(`  Enriched (hint-only, no NIP-65): ${authorsEnrichedHintOnly}`);
+  console.log(`  Zero hints: ${authorsWithZeroHints}`);
+  console.log(`Relays added: ${relaysAdded} (${authorsEnriched} authors, avg ${authorsEnriched > 0 ? (relaysAdded / authorsEnriched).toFixed(1) : 0}/author)`);
+
+  return { relaysAdded, authorsEnriched, authorsEnrichedExisting, authorsEnrichedHintOnly, hintMap: hintCounts };
+}

--- a/bench/src/normalize.ts
+++ b/bench/src/normalize.ts
@@ -6,6 +6,7 @@ const KNOWN_BAD_RELAYS = new Set([
   "wss://nwc.primal.net",
   "wss://relay.getalby.com",
   "wss://nostr.mutinywallet.com",
+  "wss://purplepag.es",
 ]);
 
 const LOCALHOST_PATTERNS = ["localhost", "127.0.0.1", "::1"];

--- a/bench/src/phase2/hint-probe.ts
+++ b/bench/src/phase2/hint-probe.ts
@@ -1,0 +1,265 @@
+/**
+ * Tier 2 hint-relay probing: query hint relays for uncovered authors
+ * and measure the recall delta vs Tier 1 verification.
+ *
+ * Fully isolated — does not modify Phase 2 types, run, verify, or report.
+ */
+
+import { RelayPool, QueryCache } from "../relay-pool.ts";
+import type { HintMap } from "../hint-enrichment.ts";
+import type {
+  AlgorithmResult,
+  AlgorithmVerification,
+  PubkeyBaseline,
+  Pubkey,
+  RelayUrl,
+} from "../types.ts";
+
+const MAX_HINT_RELAYS_PER_AUTHOR = 2;
+
+interface HintProbeResult {
+  uncoveredAuthors: number;
+  authorsWithHints: number;
+  authorsRecovered: number;
+  supplementaryRelaysQueried: number;
+  eventsFound: number;
+  perAlgorithm: {
+    name: string;
+    tier1EvtRecall: number;
+    combinedEvtRecall: number;
+    tier1AuthRecall: number;
+    combinedAuthRecall: number;
+  }[];
+}
+
+/**
+ * After Phase 2 Tier 1, probe hint relays for uncovered authors and
+ * report combined recall.
+ */
+export async function probeHintRelays(
+  baselines: Map<Pubkey, PubkeyBaseline>,
+  cache: QueryCache,
+  algorithmResults: AlgorithmResult[],
+  algorithmVerifications: AlgorithmVerification[],
+  hintMap: HintMap,
+  options: { kinds: number[]; windowSeconds: number; maxConcurrentConns: number },
+): Promise<HintProbeResult> {
+  // 1. Identify testable-reliable authors
+  const reliableAuthors: Pubkey[] = [];
+  for (const [pubkey, baseline] of baselines) {
+    if (baseline.classification === "testable-reliable") {
+      reliableAuthors.push(pubkey);
+    }
+  }
+
+  if (reliableAuthors.length === 0) {
+    console.log("\n=== Hint Tier 2: No testable-reliable authors — skipping ===");
+    return {
+      uncoveredAuthors: 0, authorsWithHints: 0, authorsRecovered: 0,
+      supplementaryRelaysQueried: 0, eventsFound: 0, perAlgorithm: [],
+    };
+  }
+
+  // 2. For each algorithm, find uncovered authors (0 events found through assigned relays)
+  //    Union across algorithms to get the full set of authors to probe
+  const uncoveredByAlgo = new Map<number, Set<Pubkey>>(); // algoIdx → set
+  const allUncovered = new Set<Pubkey>();
+
+  for (let i = 0; i < algorithmResults.length; i++) {
+    const result = algorithmResults[i];
+    const uncovered = new Set<Pubkey>();
+
+    for (const pubkey of reliableAuthors) {
+      const baseline = baselines.get(pubkey)!;
+      const assigned = result.pubkeyAssignments.get(pubkey);
+
+      if (!assigned || assigned.size === 0) {
+        // Orphaned — no assigned relays
+        uncovered.add(pubkey);
+        continue;
+      }
+
+      // Check if any events were found through assigned relays
+      let foundAny = false;
+      for (const relay of assigned) {
+        const ids = cache.get(relay, pubkey);
+        if (ids && ids.size > 0) {
+          // Intersect with baseline
+          for (const id of ids) {
+            if (baseline.eventIds.has(id)) {
+              foundAny = true;
+              break;
+            }
+          }
+          if (foundAny) break;
+        }
+      }
+
+      if (!foundAny) {
+        uncovered.add(pubkey);
+      }
+    }
+
+    uncoveredByAlgo.set(i, uncovered);
+    for (const pk of uncovered) allUncovered.add(pk);
+  }
+
+  // 3. For each uncovered author, pick top hint relays not already queried in baseline
+  const probeTargets = new Map<RelayUrl, Set<Pubkey>>(); // relay → pubkeys to query
+  let authorsWithHints = 0;
+
+  for (const pubkey of allUncovered) {
+    const hints = hintMap.get(pubkey);
+    if (!hints || hints.size === 0) continue;
+
+    // Relays already in the baseline (already queried)
+    const baseline = baselines.get(pubkey)!;
+    const alreadyQueried = new Set<RelayUrl>([
+      ...baseline.relaysSucceeded,
+      ...baseline.relaysFailed,
+    ]);
+
+    // Sort hints by count descending, take top N not already queried
+    const candidates = [...hints.entries()]
+      .filter(([url]) => !alreadyQueried.has(url))
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, MAX_HINT_RELAYS_PER_AUTHOR);
+
+    if (candidates.length === 0) continue;
+    authorsWithHints++;
+
+    for (const [relayUrl] of candidates) {
+      const pubkeys = probeTargets.get(relayUrl) ?? new Set();
+      pubkeys.add(pubkey);
+      probeTargets.set(relayUrl, pubkeys);
+    }
+  }
+
+  if (probeTargets.size === 0) {
+    console.log(`\n=== Hint Tier 2: ${allUncovered.size} uncovered authors but no new hint relays to probe ===`);
+    return {
+      uncoveredAuthors: allUncovered.size, authorsWithHints: 0, authorsRecovered: 0,
+      supplementaryRelaysQueried: 0, eventsFound: 0, perAlgorithm: [],
+    };
+  }
+
+  // 4. Query hint relays
+  console.error(`\n=== Hint Tier 2: Probing ===`);
+  console.error(`Uncovered authors: ${allUncovered.size} | With hints: ${authorsWithHints} | Hint relays: ${probeTargets.size}`);
+
+  const pool = new RelayPool({
+    maxConcurrent: options.maxConcurrentConns,
+    maxOpenSockets: options.maxConcurrentConns + 10,
+    connectTimeoutMs: 10000,
+    eoseTimeoutMs: 15000,
+  });
+  const probeCache = new QueryCache();
+  const since = Math.floor(Date.now() / 1000) - options.windowSeconds;
+
+  const tasks = [...probeTargets.entries()].map(async ([relay, pubkeys]) => {
+    await pool.queryBatched(
+      relay,
+      [...pubkeys],
+      { kinds: options.kinds, since },
+      50,
+      probeCache,
+    );
+  });
+  await Promise.all(tasks);
+  pool.closeAll();
+
+  // 5. Compute per-algorithm combined recall
+  let totalEventsFound = 0;
+  let totalAuthorsRecovered = 0;
+  const perAlgorithm: HintProbeResult["perAlgorithm"] = [];
+
+  for (let i = 0; i < algorithmResults.length; i++) {
+    const result = algorithmResults[i];
+    const verification = algorithmVerifications[i];
+    const uncovered = uncoveredByAlgo.get(i)!;
+
+    let tier2Found = 0;
+    let authorsRecovered = 0;
+
+    for (const pubkey of uncovered) {
+      const baseline = baselines.get(pubkey)!;
+      if (baseline.eventIds.size === 0) continue;
+
+      // Collect events from hint relays for this pubkey
+      const hintRelays = [...(probeTargets.keys())].filter(
+        (relay) => probeTargets.get(relay)!.has(pubkey),
+      );
+      const foundIds = new Set<string>();
+      for (const relay of hintRelays) {
+        const ids = probeCache.get(relay, pubkey);
+        if (ids) {
+          for (const id of ids) {
+            if (baseline.eventIds.has(id)) foundIds.add(id);
+          }
+        }
+      }
+
+      if (foundIds.size > 0) {
+        tier2Found += foundIds.size;
+        authorsRecovered++;
+      }
+    }
+
+    const totalBaseline = verification.totalBaselineEventsReliable;
+    const tier1Found = verification.totalFoundEventsReliable;
+    const combinedFound = tier1Found + tier2Found;
+
+    const tier1AuthRecall = verification.authorRecallRate;
+    const combinedAuthRecall = reliableAuthors.length > 0
+      ? (verification.authorsWithEvents + authorsRecovered) / reliableAuthors.length
+      : 0;
+
+    perAlgorithm.push({
+      name: result.name,
+      tier1EvtRecall: totalBaseline > 0 ? tier1Found / totalBaseline : 0,
+      combinedEvtRecall: totalBaseline > 0 ? combinedFound / totalBaseline : 0,
+      tier1AuthRecall,
+      combinedAuthRecall,
+    });
+
+    totalEventsFound += tier2Found;
+    if (i === 0) totalAuthorsRecovered = authorsRecovered;
+  }
+
+  // 6. Print results
+  const pct = (n: number) => `${(n * 100).toFixed(1)}%`;
+
+  console.log(`\n=== Hint Tier 2: Combined Recall ===`);
+  console.log(`Uncovered authors: ${allUncovered.size} | With hints: ${authorsWithHints} | Relays probed: ${probeTargets.size}`);
+  console.log(`Events found in Tier 2: ${totalEventsFound} | Authors recovered: ${totalAuthorsRecovered}`);
+  console.log("");
+
+  const headers = ["Algorithm", "T1 EvtR", "T1+T2 EvtR", "T1 AuthR", "T1+T2 AuthR"];
+  const widths = [32, 10, 12, 10, 12];
+  const pad = (s: string, w: number, left = false) => left ? s.padEnd(w) : s.padStart(w);
+  const headerRow = headers.map((h, i) => pad(h, widths[i], i === 0)).join(" | ");
+  const separator = widths.map((w) => "-".repeat(w)).join("-+-");
+
+  console.log(`  ${headerRow}`);
+  console.log(`  ${separator}`);
+
+  for (const alg of perAlgorithm) {
+    const row = [
+      pad(alg.name, widths[0], true),
+      pad(pct(alg.tier1EvtRecall), widths[1]),
+      pad(pct(alg.combinedEvtRecall), widths[2]),
+      pad(pct(alg.tier1AuthRecall), widths[3]),
+      pad(pct(alg.combinedAuthRecall), widths[4]),
+    ].join(" | ");
+    console.log(`  ${row}`);
+  }
+
+  return {
+    uncoveredAuthors: allUncovered.size,
+    authorsWithHints,
+    authorsRecovered: totalAuthorsRecovered,
+    supplementaryRelaysQueried: probeTargets.size,
+    eventsFound: totalEventsFound,
+    perAlgorithm,
+  };
+}

--- a/bench/src/relay-scores.ts
+++ b/bench/src/relay-scores.ts
@@ -21,14 +21,15 @@ const DECAY_FACTOR = 0.95; // exponential decay per session
 const MAX_SESSION_HISTORY = 10; // keep last N session rates for trend
 const TREND_MIN_SESSIONS = 3; // minimum sessions before computing trend
 
-function scorePath(pubkeyPrefix: string, window: number, filterMode?: string): string {
+function scorePath(pubkeyPrefix: string, window: number, filterMode?: string, algorithmId?: string): string {
   const suffix = filterMode ? `_${filterMode}` : "";
-  return `${CACHE_DIR}/relay_scores_${pubkeyPrefix}_${window}${suffix}.json`;
+  const algoSuffix = algorithmId ? `_${algorithmId}` : "";
+  return `${CACHE_DIR}/relay_scores_${pubkeyPrefix}_${window}${suffix}${algoSuffix}.json`;
 }
 
-export function loadRelayScores(pubkey: string, windowSeconds: number, filterMode?: string): RelayScoreDB {
+export function loadRelayScores(pubkey: string, windowSeconds: number, filterMode?: string, algorithmId?: string): RelayScoreDB {
   const prefix = pubkey.slice(0, 16);
-  const path = scorePath(prefix, windowSeconds, filterMode);
+  const path = scorePath(prefix, windowSeconds, filterMode, algorithmId);
 
   try {
     const raw = Deno.readTextFileSync(path);
@@ -148,10 +149,10 @@ export function updateRelayScores(
   return db;
 }
 
-export async function saveRelayScores(db: RelayScoreDB, filterMode?: string): Promise<void> {
+export async function saveRelayScores(db: RelayScoreDB, filterMode?: string, algorithmId?: string): Promise<void> {
   await Deno.mkdir(CACHE_DIR, { recursive: true });
   const prefix = db.pubkey.slice(0, 16);
-  const path = scorePath(prefix, db.windowSeconds, filterMode);
+  const path = scorePath(prefix, db.windowSeconds, filterMode, algorithmId);
   const tmp = await Deno.makeTempFile({ dir: CACHE_DIR });
   try {
     await Deno.writeTextFile(tmp, JSON.stringify(db, null, 2));

--- a/bench/src/types.ts
+++ b/bench/src/types.ts
@@ -156,6 +156,7 @@ export interface CliOptions {
   nip66Filter: Nip66FilterMode;
   nip66TtlMs?: number;
   noPhase2Cache: boolean;
+  enrichHints: boolean;
 }
 
 export interface SerializedAlgorithmResult {


### PR DESCRIPTION
## Summary

- Extract shared Beta distribution sampling (`beta.ts`) from `welshman-thompson.ts`
- Add **FD+Thompson** algorithm: per-author relay selection ranked by Beta-sampled delivery scores, without the popularity weight `(1 + log(weight))` used by Welshman+Thompson
- Generalise Thompson prior injection and learning in `main.ts` via `THOMPSON_IDS` set

## Improvement over baseline Filter Decomposition

FD+Thompson adds Thompson Sampling to rust-nostr's existing Filter Decomposition — same per-author structure, but ranking relays by learned delivery scores instead of lexicographic order. Single-session results at 1yr, cap@20:

| Profile (follows) | Baseline FD | FD+Thompson | Gain (absolute) | Gain (relative) |
|---|:---:|:---:|:---:|:---:|
| fiatjaf (194) | 25.5% | **39.0%** | +13.5pp | +53% |
| Gato (399) | 13.1% | **20.6%** | +7.5pp | +57% |
| ODELL (1,079) | 21.6% | **29.1%** | +7.5pp | +35% |
| Telluride (2,747) | 32.3% | **38.6%** | +6.3pp | +20% |
| **4-profile mean** | **23.1%** | **31.8%** | **+8.7pp** | **+38%** |

Learning from delivery adds +8.7 percentage points on average even in a single session — no multi-session convergence needed. The gain is largest on small graphs (+53% relative for fiatjaf) where lexicographic ordering wastes slots on relays that prune aggressively.

## FD+Thompson vs Welshman+Thompson

| Profile | Follows | Algorithm | Evt Recall | Auth Recall | Median Recall |
|---|---|---|---|---|---|
| fiatjaf | 194 | FD+Thompson | **39.0%** | **80.4%** | **39.4%** |
| | | Welshman+Thompson | 37.0% | 78.6% | 18.7% |
| Gato | 399 | FD+Thompson | 20.6% | **89.5%** | 97.9% |
| | | Welshman+Thompson | **22.5%** | 87.4% | **98.5%** |
| ODELL | 1,079 | FD+Thompson | 29.1% | 79.7% | 55.0% |
| | | Welshman+Thompson | **30.5%** | **82.7%** | **64.0%** |
| Telluride | 2,747 | FD+Thompson | **38.6%** | 81.4% | 77.6% |
| | | Welshman+Thompson | **38.6%** | **84.2%** | **82.4%** |

**Takeaway**: Welshman+Thompson's popularity weight helps at larger follow counts (Gato/ODELL/Telluride). FD+Thompson wins on the small fiatjaf graph where popularity bias over-concentrates on relays that prune old events. Both far exceed their stateless baselines (+38% relative for FD, +45% relative for Welshman).

## Test plan

- [ ] `cd bench && deno check src/algorithms/fd-thompson.ts`
- [ ] `cd bench && deno check src/algorithms/beta.ts`
- [ ] `deno task bench -- --target <npub> --algorithms fd-thompson,welshman-thompson --verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FD+Thompson per-author relay selection and Beta sampling utility for Thompson sampling.
  * Per-algorithm Thompson priors with persistent storage and per-algorithm learning/metrics.
  * Optional relay-hint enrichment and a hint-probing step (CLI flag plus probe task) to augment author→relay mappings and improve Phase 2 recall.

* **Documentation**
  * Updated README, implementation guide, benchmark reports, and client upgrade notes with FD+Thompson, hinting, and probe details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->