### PR TITLE
Add hybrid outbox enrichment algorithm and decision tree

### DIFF
--- a/IMPLEMENTATION-GUIDE.md
+++ b/IMPLEMENTATION-GUIDE.md
@@ -7,9 +7,16 @@ Detailed recommendations for adding or upgrading outbox relay selection in your 
 ```
 What's your starting point?
 │
-├─ No outbox yet?
-│  └─ Start here → hardcode relay.damus.io + nos.lol (8% 1yr recall)
-│     then upgrade to basic outbox when ready
+├─ No outbox yet (hardcoded app relays / broadcast)?
+│  │
+│  ├─ Can you rewrite your relay routing layer?
+│  │  └─ Yes → Full outbox (Steps 1a → 4 in README)
+│  │           Best recall (84-89% 1yr), biggest engineering investment
+│  │
+│  └─ Need to preserve feed latency or can't change routing?
+│     └─ Hybrid outbox — add outbox queries to profile/event/thread hooks
+│        80% 1yr recall, ~80 LOC, no routing layer changes
+│        See README § Hybrid outbox for code
 │
 ├─ Basic outbox (real-time feeds)?
 │  ├─ Need connection minimization? → Greedy Set-Cover (16% 1yr, 84% 7d)
@@ -19,7 +26,8 @@ What's your starting point?
 ├─ Historical event recall (archival, search)?
 │  ├─ Can persist state across sessions?
 │  │  ├─ Using Welshman/Coracle?  → Welshman+Thompson Sampling (89% 1yr)
-│  │  └─ Using rust-nostr?        → FD+Thompson (84% 1yr after 5 sessions)
+│  │  ├─ Using rust-nostr?        → FD+Thompson (84% 1yr after 5 sessions)
+│  │  └─ Using app relays?        → Hybrid+Thompson (80% 1yr, no routing changes)
 │  └─ Stateless?                  → Filter Decomposition (25% 1yr) or
 │                                   Weighted Stochastic / Welshman (24% 1yr)
 │

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The 3pp gap between hybrid (80%) and full outbox (83%) at 1yr comes from the ful
 
 **Decision tree:**
 
-```
+```text
 Do you have a routing layer that selects relays per-author?
 ├─ Yes → Add Thompson Sampling to it (Step 4)
 │        Welshman+Thompson: 89% 1yr | FD+Thompson: 84% 1yr

--- a/bench/src/algorithms/ditto-mew.ts
+++ b/bench/src/algorithms/ditto-mew.ts
@@ -1,0 +1,60 @@
+import type {
+  AlgorithmResult,
+  AlgorithmParams,
+  BenchmarkInput,
+  Pubkey,
+  RelayUrl,
+} from "../types.ts";
+
+/**
+ * Ditto-Mew baseline: broadcasts all feed queries to 4 hardcoded app relays
+ * regardless of followed authors' NIP-65 declarations.
+ *
+ * This mirrors ditto-mew's actual feed behavior: no per-author routing,
+ * no outbox model for feeds. Every author is assigned to every app relay.
+ * Phase 2 verification measures what those relays actually return.
+ *
+ * Ref: https://gitlab.com/soapbox-pub/ditto-mew (NostrProvider.tsx reqRouter)
+ */
+const APP_RELAYS: RelayUrl[] = [
+  "wss://relay.ditto.pub",
+  "wss://relay.primal.net",
+  "wss://relay.damus.io",
+  "wss://nos.lol",
+];
+
+export function dittoMew(
+  input: BenchmarkInput,
+  params: AlgorithmParams,
+  _rng: () => number,
+): AlgorithmResult {
+  const start = performance.now();
+
+  const relayAssignments = new Map<RelayUrl, Set<Pubkey>>();
+  const pubkeyAssignments = new Map<Pubkey, Set<RelayUrl>>();
+
+  // Initialize relay assignments with all follows
+  const allFollows = new Set(input.follows);
+  for (const relay of APP_RELAYS) {
+    relayAssignments.set(relay, new Set(allFollows));
+  }
+
+  // Every author assigned to every app relay (broadcast)
+  const relaySet = new Set(APP_RELAYS);
+  for (const pubkey of input.follows) {
+    pubkeyAssignments.set(pubkey, new Set(relaySet));
+  }
+
+  return {
+    name: "Ditto-Mew (4 app relays)",
+    relayAssignments,
+    pubkeyAssignments,
+    orphanedPubkeys: new Set<Pubkey>(), // no orphans — everyone is assigned
+    params,
+    executionTimeMs: performance.now() - start,
+    notes: [
+      `Broadcast: ${input.follows.length} authors × ${APP_RELAYS.length} relays`,
+      `No per-author routing — mirrors ditto-mew feed behavior`,
+    ],
+  };
+}

--- a/bench/src/algorithms/ditto-outbox.ts
+++ b/bench/src/algorithms/ditto-outbox.ts
@@ -1,0 +1,130 @@
+import type {
+  AlgorithmResult,
+  AlgorithmParams,
+  BenchmarkInput,
+  Pubkey,
+  RelayUrl,
+} from "../types.ts";
+import { sampleBeta } from "./beta.ts";
+
+/**
+ * Ditto-Mew + Outbox Thompson
+ *
+ * Models the implementation where profile views combine:
+ * 1. The 4 hardcoded app relays (broadcast, same as baseline ditto-mew)
+ * 2. Up to 3 of the viewed author's NIP-65 write relays, scored by Thompson Sampling
+ *
+ * This matches what the useProfileFeed.ts outbox routing does:
+ * - App relay query runs unchanged (fast path)
+ * - In parallel, fetch author's kind 10002, extract write relays,
+ *   score with Thompson, pick top 3, query them
+ *
+ * Cold start: Beta(1,1) = uniform random = no worse than baseline.
+ * Warm start: relays that historically delivered get higher scores.
+ *
+ * The main feed is NOT modeled here — this only benchmarks the
+ * profile/event lookup path where outbox routing is active.
+ */
+const APP_RELAYS: RelayUrl[] = [
+  "wss://relay.ditto.pub",
+  "wss://relay.primal.net",
+  "wss://relay.damus.io",
+  "wss://nos.lol",
+];
+
+export function dittoOutbox(
+  input: BenchmarkInput,
+  params: AlgorithmParams,
+  rng: () => number,
+): AlgorithmResult {
+  const start = performance.now();
+  const writeLimit = params.writeLimit ?? 3;
+  const relayPriors = params.relayPriors;
+
+  const relayAssignments = new Map<RelayUrl, Set<Pubkey>>();
+  const pubkeyAssignments = new Map<Pubkey, Set<RelayUrl>>();
+  const orphanedPubkeys = new Set<Pubkey>();
+
+  // Initialize app relay assignments
+  const allFollows = new Set(input.follows);
+  for (const relay of APP_RELAYS) {
+    relayAssignments.set(relay, new Set(allFollows));
+  }
+
+  let priorsUsed = 0;
+  const priorsTotal = relayPriors ? relayPriors.size : 0;
+  let authorsWithOutbox = 0;
+
+  for (const pubkey of input.follows) {
+    // Every author gets all 4 app relays (broadcast baseline)
+    const selected = new Set<RelayUrl>(APP_RELAYS);
+
+    // Additionally, look up their NIP-65 write relays and pick top 3 by Thompson
+    const authorRelays = input.writerToRelays.get(pubkey);
+    if (authorRelays && authorRelays.size > 0) {
+      // Filter out relays already in the app set
+      const appSet = new Set(APP_RELAYS);
+      const candidates: RelayUrl[] = [];
+      for (const relay of authorRelays) {
+        if (!appSet.has(relay)) {
+          candidates.push(relay);
+        }
+      }
+
+      if (candidates.length > 0) {
+        // Score each candidate by Thompson sample
+        const scored: { relay: RelayUrl; score: number }[] = [];
+        for (const relay of candidates) {
+          const prior = relayPriors?.get(relay);
+          const sample = prior
+            ? sampleBeta(prior.alpha, prior.beta, rng)
+            : sampleBeta(1, 1, rng);
+
+          if (prior) priorsUsed++;
+          scored.push({ relay, score: sample });
+        }
+
+        // Sort by score descending
+        scored.sort((a, b) => {
+          if (a.score !== b.score) return b.score - a.score;
+          return a.relay < b.relay ? -1 : a.relay > b.relay ? 1 : 0;
+        });
+
+        // Pick top writeLimit
+        const limit = Math.min(writeLimit, scored.length);
+        for (let i = 0; i < limit; i++) {
+          const relay = scored[i].relay;
+          selected.add(relay);
+
+          const writers = relayAssignments.get(relay) ?? new Set<Pubkey>();
+          writers.add(pubkey);
+          relayAssignments.set(relay, writers);
+        }
+
+        authorsWithOutbox++;
+      }
+    }
+
+    pubkeyAssignments.set(pubkey, selected);
+  }
+
+  const notes: string[] = [
+    `App relays: ${APP_RELAYS.length} (broadcast to all ${input.follows.length} authors)`,
+    `Outbox: ${authorsWithOutbox}/${input.follows.length} authors got additional write relays (top ${writeLimit})`,
+  ];
+  if (relayPriors && relayPriors.size > 0) {
+    notes.push(`Thompson Sampling: ${priorsTotal} relay priors loaded, ${priorsUsed} prior lookups used`);
+  } else {
+    notes.push("Thompson Sampling: cold start (uniform priors)");
+  }
+
+  return {
+    name: "Ditto+Outbox Thompson",
+    relayAssignments,
+    pubkeyAssignments,
+    orphanedPubkeys, // no orphans — everyone gets app relays at minimum
+    params,
+    executionTimeMs: performance.now() - start,
+    notes,
+  };
+}

--- a/bench/src/algorithms/ditto-outbox.ts
+++ b/bench/src/algorithms/ditto-outbox.ts
@@ -38,7 +38,7 @@ export function dittoOutbox(
   rng: () => number,
 ): AlgorithmResult {
   const start = performance.now();
-  const writeLimit = params.writeLimit ?? 3;
+  const writeLimit = Math.max(0, Math.floor(Number(params.writeLimit) || 3));
   const relayPriors = params.relayPriors;
 
   const relayAssignments = new Map<RelayUrl, Set<Pubkey>>();

--- a/bench/src/algorithms/mod.ts
+++ b/bench/src/algorithms/mod.ts
@@ -32,6 +32,8 @@ import { welshmanThompson } from "./welshman-thompson.ts";
 import { jumbleCoveragePruning } from "./jumble.ts";
 import { bigRelaysBaseline } from "./big-relays.ts";
 import { fdThompson } from "./fd-thompson.ts";
+import { dittoMew } from "./ditto-mew.ts";
+import { dittoOutbox } from "./ditto-outbox.ts";
 
 export interface AlgorithmEntry {
   id: string;
@@ -205,6 +207,22 @@ export const ALGORITHM_REGISTRY: AlgorithmEntry[] = [
     nativeCap: false,
     stochastic: false,
     defaults: {},
+  },
+  {
+    id: "ditto-mew",
+    name: "Ditto-Mew (4 app relays)",
+    fn: dittoMew,
+    nativeCap: true,  // fixed relay set, ignores maxConnections
+    stochastic: false,
+    defaults: {},
+  },
+  {
+    id: "ditto-outbox",
+    name: "Ditto+Outbox Thompson",
+    fn: dittoOutbox,
+    nativeCap: false,
+    stochastic: true,
+    defaults: { writeLimit: 3 },
   },
 ];
 


### PR DESCRIPTION
## Summary

- Adds **hybrid outbox enrichment** as a new algorithm category: clients with hardcoded app relays add per-author outbox queries for profile views, event lookups, and thread traversal — without rewriting their relay routing layer
- Benchmarks show **80% 1yr event recall** (vs 26% baseline), within 3pp of full Welshman+Thompson (83%)
- Adds decision tree for app devs choosing between full outbox routing and hybrid outbox enrichment

## New files

- `bench/src/algorithms/ditto-mew.ts` — baseline: 4 hardcoded app relays (broadcast)
- `bench/src/algorithms/ditto-outbox.ts` — hybrid: app relays + top 3 author write relays scored by Thompson Sampling

## Doc changes

- **README**: new "Two ways to add outbox" section with decision tree, hybrid outbox code examples, algorithm quick reference entry, Ditto-Mew client row, step table updated with Step 1b
- **IMPLEMENTATION-GUIDE**: decision tree updated with hybrid path

## Benchmark results (fiatjaf/194 follows, 1yr window)

| Algorithm | 1yr Event Recall | 1yr Author Recall |
|---|--:|--:|
| Ditto-Mew baseline (4 app relays) | 25.9% | 57.6% |
| **Ditto+Outbox Thompson (hybrid)** | **79.8%** | **82.8%** |
| Welshman+Thompson (full outbox) | 82.9% | 82.8% |

## Test plan

- [x] Benchmark runs: `deno task bench <hex> --algorithms ditto-mew,ditto-outbox,welshman-thompson --verify --verify-window 94608000`
- [ ] Review decision tree framing — presents tradeoffs rather than ranking one approach over another
- [ ] Review code examples in README for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded implementation guide with deeper decision branches for Full vs Hybrid outbox, recall/effort guidance, and links to relevant README sections.
  * Updated README with split entry paths, a "Two ways to add outbox" comparison, algorithm quick-reference updates, benchmarks narrative, and practical hybrid patterns.

* **New Features**
  * Added two new benchmark algorithms: a 4-app-relay baseline and a Ditto+Outbox (Thompson sampling) variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->