### PR TITLE
Add latency benchmarks: EOSE-race, TTFE, and timeout guidance

### DIFF
--- a/IMPLEMENTATION-GUIDE.md
+++ b/IMPLEMENTATION-GUIDE.md
@@ -147,18 +147,99 @@ migration — it works equally well for delivery verification.
 
 See [README.md § Delivery check](README.md#delivery-check-self-healing) for code.
 
-### 4. Cap at 20 connections
+### 4. Set timeouts by use case (latency-coverage tradeoff)
+
+**Impact: determines how fast your UI feels vs how much content users see**
+
+Every relay query faces a tradeoff: wait longer → more events, but slower UI. The right timeout depends on what you're loading. Benchmarked across 7 profiles (194–2,784 follows):
+
+```
+What are you loading?
+│
+├─ Main feed (timeline)
+│  └─ EOSE-race: show events as they stream in,
+│     cut off at first EOSE + 2s grace
+│     → First event: 530-670ms
+│     → 85-99% completeness at cutoff
+│     → Done in 2-3s total wall-clock
+│
+├─ Profile view
+│  └─ Query author's top 3 write relays + app relays in parallel
+│     3s timeout
+│     → 750-920ms median TTFE, 96-100% hit rate
+│
+├─ Event lookup / reply context
+│  └─ Try relay hint from e-tag first (500ms timeout)
+│     Fall back to author's write relays (2s timeout)
+│
+├─ Search / archival
+│  └─ Query all selected relays, 15s timeout per relay
+│     → ~100% completeness, accept 5-15s latency
+│
+└─ Notification badge / unread count
+   └─ EOSE-race: first EOSE + 500ms grace
+      → 70-76% completeness, sub-second total
+```
+
+**EOSE-race implementation.** Query all relays in parallel. When the first relay sends EOSE, start a grace timer. Cut off when the timer fires:
+
+```typescript
+function eoseRace(pool, relays, filter, graceMs = 2000) {
+  const events = new Map();  // deduplicate by event ID
+  let firstEose = false;
+  let graceTimer;
+
+  return new Promise(resolve => {
+    const sub = pool.subscribe(relays, filter, {
+      onevent(event) {
+        if (!events.has(event.id)) {
+          events.set(event.id, event);
+          onNewEvent(event);  // render immediately
+        }
+      },
+      oneose() {
+        if (!firstEose) {
+          firstEose = true;
+          graceTimer = setTimeout(() => {
+            sub.close();
+            resolve([...events.values()]);
+          }, graceMs);
+        }
+      }
+    });
+
+    // Hard timeout: 15s regardless
+    setTimeout(() => { sub.close(); resolve([...events.values()]); }, 15000);
+  });
+}
+```
+
+**Grace period decision matrix** (from 7-profile benchmark, EOSE-race simulation):
+
+| Grace period | Completeness range | Best for |
+|:---:|:---:|---|
+| +0ms | 0–62% | Only 1-2 relay setups (Big Relays, Ditto-Mew) |
+| +500ms | 5–93% | Notification badges, unread counts |
+| +1s | 5–93% | Unreliable — too variable across profile sizes |
+| **+2s** | **76–99%** | **Main feeds — best balance of speed and coverage** |
+| +5s | 89–100% | Archival, search, completeness-critical paths |
+
+The 0–62% range at +0ms means: if your algorithm queries 20 relays, the first EOSE arrives from the fastest relay but 19 others haven't reported yet. Waiting 2s lets most of them finish. For profiles with 2,000+ follows (more relays, more variance), +2s gets 76-87% — consider +5s for completeness-critical use cases.
+
+*Data: 7 cross-profile benchmarks (194–2,784 follows). See [README.md § Latency](README.md#4-latency-when-to-stop-waiting-for-relays) for the summary and [OUTBOX-REPORT.md § 8.6](OUTBOX-REPORT.md#86-latency-simulation) for full data.*
+
+### 5. Cap at 20 connections
 
 All algorithms reach within 1-2% of their unlimited ceiling by 20
 connections. Greedy at 10 already achieves 93-97% of its unlimited coverage.
 
-### 5. Target 2-3 relays per author
+### 6. Target 2-3 relays per author
 
 1 relay = fragile (relay goes down or silently drops a write, you lose events).
 2 = redundancy. 3+ = diminishing returns. 7 of 9 implementations with
 per-pubkey limits default to 2 or 3.
 
-### 6. Handle missing relay lists gracefully
+### 7. Handle missing relay lists gracefully
 
 On paper, 20-44% of followed users lack kind 10002 — but [dead account
 analysis](bench/NIP66-COMPARISON-REPORT.md#5-dead-account-analysis) shows
@@ -183,7 +264,7 @@ automates this server-side via negentropy sync, but is a proof-of-concept (not
 production). Client-side detection of "relay listed but no data from this
 author" would catch both missing relay lists and stale migrations.
 
-### 7. Diversify bootstrap relays
+### 8. Diversify bootstrap relays
 
 8/13 analyzed clients hardcode relay.damus.io. 6/13 depend on purplepag.es
 for indexing. Consider diversifying:

--- a/IMPLEMENTATION-GUIDE.md
+++ b/IMPLEMENTATION-GUIDE.md
@@ -214,6 +214,16 @@ function eoseRace(pool, relays, filter, graceMs = 2000) {
 }
 ```
 
+**Coverage and latency are directly opposed.** More relays = more events, but longer to collect them:
+
+| Relays queried | Recall ceiling | At first EOSE | At +2s | At +5s |
+|:---:|:---:|:---:|:---:|:---:|
+| 2 (Big Relays) | 50–77% | 100% | 100% | 100% |
+| 4 (Ditto-Mew) | 62–86% | 8–84% | 85–100% | 85–100% |
+| 20 (Outbox) | 81–98% | 0–62% | 76–99% | 89–100% |
+
+Two relays finish instantly but miss half the events. Twenty relays find nearly everything but take 2-5s. Hybrid outbox side-steps this: show app relay events immediately, stream in outbox events in the background.
+
 **Grace period decision matrix** (from 7-profile benchmark, EOSE-race simulation):
 
 | Grace period | Completeness range | Best for |

--- a/IMPLEMENTATION-GUIDE.md
+++ b/IMPLEMENTATION-GUIDE.md
@@ -153,7 +153,7 @@ See [README.md § Delivery check](README.md#delivery-check-self-healing) for cod
 
 Every relay query faces a tradeoff: wait longer → more events, but slower UI. The right timeout depends on what you're loading. Benchmarked across 7 profiles (194–2,784 follows):
 
-```
+```text
 What are you loading?
 │
 ├─ Main feed (timeline)

--- a/IMPLEMENTATION-GUIDE.md
+++ b/IMPLEMENTATION-GUIDE.md
@@ -160,7 +160,7 @@ What are you loading?
 │  └─ EOSE-race: show events as they stream in,
 │     cut off at first EOSE + 2s grace
 │     → First event: 530-670ms
-│     → 85-99% completeness at cutoff
+│     → 86-99% completeness at cutoff
 │     → Done in 2-3s total wall-clock
 │
 ├─ Profile view
@@ -220,7 +220,7 @@ function eoseRace(pool, relays, filter, graceMs = 2000) {
 |:---:|:---:|:---:|:---:|:---:|
 | 2 (Big Relays) | 50–77% | 100% | 100% | 100% |
 | 4 (Ditto-Mew) | 62–86% | 8–84% | 85–100% | 85–100% |
-| 20 (Outbox) | 81–98% | 0–62% | 76–99% | 89–100% |
+| 20 (Outbox) | 81–98% | 0–62% | 86–99% | 89–100% |
 
 Two relays finish instantly but miss half the events. Twenty relays find nearly everything but take 2-5s. Hybrid outbox side-steps this: show app relay events immediately, stream in outbox events in the background.
 
@@ -231,12 +231,146 @@ Two relays finish instantly but miss half the events. Twenty relays find nearly 
 | +0ms | 0–62% | Only 1-2 relay setups (Big Relays, Ditto-Mew) |
 | +500ms | 5–93% | Notification badges, unread counts |
 | +1s | 5–93% | Unreliable — too variable across profile sizes |
-| **+2s** | **76–99%** | **Main feeds — best balance of speed and coverage** |
+| **+2s** | **86–99%** | **Main feeds — best balance of speed and coverage** |
 | +5s | 89–100% | Archival, search, completeness-critical paths |
 
-The 0–62% range at +0ms means: if your algorithm queries 20 relays, the first EOSE arrives from the fastest relay but 19 others haven't reported yet. Waiting 2s lets most of them finish. For profiles with 2,000+ follows (more relays, more variance), +2s gets 76-87% — consider +5s for completeness-critical use cases.
+The 0–62% range at +0ms means: if your algorithm queries 20 relays, the first EOSE arrives from the fastest relay but 19 others haven't reported yet. Waiting 2s lets most of them finish. For the largest profiles (2,700+ follows), +2s gets 86-87% — consider +5s for completeness-critical use cases.
 
 *Data: 7 cross-profile benchmarks (194–2,784 follows). See [README.md § Latency](README.md#4-latency-when-to-stop-waiting-for-relays) for the summary and [OUTBOX-REPORT.md § 8.6](OUTBOX-REPORT.md#86-latency-simulation) for full data.*
+
+#### Showing late-arriving events in the UI
+
+The EOSE-race means your feed renders in <1s but more events trickle in over the next 2-5s. You need a UI pattern that shows the fast results immediately without reflowing content when stragglers arrive. This is a solved problem — Twitter, Mastodon, and federated search engines all handle it.
+
+**Pattern 1: "N new posts" banner (recommended for feeds)**
+
+The user sees the initial load. Late-arriving events accumulate in a buffer. A non-intrusive banner appears when the buffer has new content:
+
+```text
+┌─────────────────────────────────┐
+│  ↑ 3 more posts                 │  ← banner appears after grace period
+├─────────────────────────────────┤
+│  Alice: just mass-adopted nostr │  ← first-EOSE events (visible immediately)
+│  Bob: gm                        │
+│  Carol: building on nostr...    │
+│                                 │
+│  Dave: new relay just dropped   │
+│  Eve: outbox model is fire      │
+└─────────────────────────────────┘
+```
+
+Tapping the banner scrolls up and inserts the new events in chronological position. This avoids layout shift — the user's reading position never jumps.
+
+**Pattern 2: Shimmer placeholder rows (good for profile views)**
+
+When loading a profile via outbox (3 write relays, 3s timeout), show skeleton rows that resolve into real events:
+
+```text
+┌─────────────────────────────────┐
+│  @fiatjaf                       │
+│  194 follows · 3 write relays   │
+├─────────────────────────────────┤
+│  Real note from relay 1         │  ← arrived at 400ms
+│  Real note from relay 1         │
+│  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │  ← shimmer placeholder
+│  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │  ← shimmer placeholder
+└─────────────────────────────────┘
+
+          ↓ 800ms later ↓
+
+┌─────────────────────────────────┐
+│  @fiatjaf                       │
+│  194 follows · 3 write relays   │
+├─────────────────────────────────┤
+│  Real note from relay 1         │
+│  Real note from relay 1         │
+│  Real note from relay 2         │  ← resolved
+│  Real note from relay 3         │  ← resolved
+└─────────────────────────────────┘
+```
+
+Only show skeletons when you *expect* more content (you've queried relays that haven't responded yet). Remove them when the timeout fires, even if empty.
+
+**Pattern 3: Relay progress counter (power-user addition)**
+
+A subtle status line showing relay progress. Useful during longer queries (search, archival) or as a trust signal for users who want to see outbox routing working:
+
+```text
+┌─────────────────────────────────┐
+│  Timeline                       │
+│  ✓ 14 of 18 relays · 2 slow    │  ← progress counter
+├─────────────────────────────────┤
+│  [events...]                    │
+└─────────────────────────────────┘
+
+          ↓ grace period fires ↓
+
+┌─────────────────────────────────┐
+│  Timeline                       │
+│                                 │  ← counter disappears
+├─────────────────────────────────┤
+│  [events...]                    │
+└─────────────────────────────────┘
+```
+
+**Implementation with EOSE-race.** Extend the `eoseRace` function to support a UI callback:
+
+```typescript
+function eoseRaceFeed(pool, relays, filter, {
+  graceMs = 2000,
+  onEvent,          // (event) => void — render immediately
+  onLateEvents,     // (events[]) => void — show "N new posts" banner
+  onRelayProgress,  // (responded: number, total: number) => void
+} = {}) {
+  const earlyEvents = new Map();   // events before grace fires
+  const lateEvents = new Map();    // events after grace fires
+  let graceFired = false;
+  let responded = 0;
+  const total = relays.length;
+
+  const sub = pool.subscribe(relays, filter, {
+    onevent(event) {
+      if (earlyEvents.has(event.id) || lateEvents.has(event.id)) return;
+      if (!graceFired) {
+        earlyEvents.set(event.id, event);
+        onEvent?.(event);  // render in feed immediately
+      } else {
+        lateEvents.set(event.id, event);  // buffer for banner
+      }
+    },
+    oneose() {
+      responded++;
+      onRelayProgress?.(responded, total);
+      if (responded === 1) {
+        // First EOSE — start grace timer
+        setTimeout(() => {
+          graceFired = true;
+          // Any events already buffered? Show banner immediately.
+          // Future events go to lateEvents buffer.
+        }, graceMs);
+      }
+    }
+  });
+
+  // Hard timeout
+  setTimeout(() => {
+    sub.close();
+    if (lateEvents.size > 0) onLateEvents?.([...lateEvents.values()]);
+  }, 15000);
+}
+```
+
+**Which pattern to use where:**
+
+| Context | Pattern | Why |
+|---|---|---|
+| Main feed (timeline) | "N new posts" banner | Avoids layout shift while reading |
+| Profile view | Shimmer placeholders | User expects content to fill in; short wait (750-920ms) |
+| Thread / reply chain | Shimmer for missing parents | Conversations should look complete; fill gaps as relays respond |
+| Search / archival | Relay progress counter | Longer waits (5-15s); counter sets expectations |
+| Hybrid outbox feed | Banner for outbox layer | App relay events show instantly; banner for outbox additions |
+
+These patterns are proven at scale: Twitter uses the banner for timeline updates, Facebook and LinkedIn use shimmer for profile/card loading, and Slack/Confluence use progress counters for federated search. The nostr multi-relay model maps directly to the federated search model — you're querying N independent sources and progressively merging results.
 
 ### 5. Cap at 20 connections
 

--- a/OUTBOX-REPORT.md
+++ b/OUTBOX-REPORT.md
@@ -1048,7 +1048,7 @@ Big Relays reaches full completeness at +0ms on most profiles (only 1-2 relays w
     |:---:|:---:|:---:|:---:|:---:|
     | 2 (Big Relays) | 50–77% | 100% | 100% | 100% |
     | 4 (Ditto-Mew) | 62–86% | 8–84% | 85–100% | 85–100% |
-    | 20 (Outbox) | 81–98% | 0–62% | 76–99% | 89–100% |
+    | 20 (Outbox) | 81–98% | 0–62% | 86–99% | 89–100% |
 
     Two relays finish instantly but miss half the events. Twenty relays find nearly everything but take 2-5s to converge. Hybrid outbox side-steps this: show app relay events immediately (2-4 relay speed), stream in outbox events in the background (20-relay coverage).
 
@@ -1092,7 +1092,7 @@ Based on patterns observed across all implementations and benchmark results:
 
 8. **Support NIP-17 DM relays.** Only 4 of 10 mature implementations fully route DMs via kind 10050 relays. Kind 10050 is straightforward to implement and provides meaningful privacy benefits for direct messaging.
 
-9. **EOSE-race with 2s grace is the practical feed timeout.** Across 7 profiles, waiting 2s after the first relay finishes captures 76-99% of eventual recall — enough for feeds, where showing *most* events quickly beats showing *all* events slowly. The tradeoff is fundamental: 2 relays give instant completeness (100% at +0ms) but low absolute recall (50-77%). 20 outbox relays give high recall (81-98%) but need 2-5s to converge. Hybrid outbox bridges this — app relay events arrive instantly, outbox events stream in. For completeness-critical paths (archival, search), 5s gets to ~100% on all but the largest profiles (2,700+ follows need 15s due to timeout overhead).
+9. **EOSE-race with 2s grace is the practical feed timeout.** Across 7 profiles, waiting 2s after the first relay finishes captures 86-99% of eventual recall — enough for feeds, where showing *most* events quickly beats showing *all* events slowly. The tradeoff is fundamental: 2 relays give instant completeness (100% at +0ms) but low absolute recall (50-77%). 20 outbox relays give high recall (81-98%) but need 2-5s to converge. Hybrid outbox bridges this — app relay events arrive instantly, outbox events stream in. For completeness-critical paths (archival, search), 5s gets to ~100% on all but the largest profiles (2,700+ follows need 15s due to timeout overhead).
 
 10. **Aggregator results are surprisingly poor.** Primal reaches 32% recall at 7d (6-profile mean) and <1% at 3yr — worse than Popular+Random (damus + nos.lol + 2 random relays) at every window. This is unexpected: an aggregator that proxies tens if not hundreds of relays should in theory outperform 4 random connections. This may indicate a limitation in the benchmark methodology rather than a real-world indictment of aggregators.
 

--- a/OUTBOX-REPORT.md
+++ b/OUTBOX-REPORT.md
@@ -999,6 +999,8 @@ See [bench/src/algorithms/ditto-outbox.ts](bench/src/algorithms/ditto-outbox.ts)
 | ValderDama (1,082) | 635 | 658ms | 874ms | 14 | 542ms | 912ms |
 | Telluride (2,747) | 1,234 | 611ms | 829ms | 35 | 527ms | 791ms |
 
+*Follow counts differ slightly from earlier sections (e.g., ODELL 1,777 vs 1,779) because these latency benchmarks were run at a different time — follow counts change as users follow/unfollow people. The differences are small (<2%) and don't affect timing conclusions.*
+
 Feed TTFE is algorithm-invariant: it depends on the fastest relay in the selected set, and all outbox algorithms include at least one fast relay. TTFE ranges from 527ms (Telluride) to 668ms (jb55). Profile-view TTFE (top 3 write relays per author, algorithm-independent) ranges from 717ms to 1.0s median, with 96-100% hit rates.
 
 **EOSE-race simulation.** The key question for app devs: when you query 20 relays in parallel, the fastest sends EOSE first. How much recall have you captured at that point, and how much more do you get by waiting?

--- a/OUTBOX-REPORT.md
+++ b/OUTBOX-REPORT.md
@@ -983,6 +983,83 @@ The algorithm models [Ditto-Mew](https://gitlab.com/soapbox-pub/ditto-mew)'s arc
 
 See [bench/src/algorithms/ditto-outbox.ts](bench/src/algorithms/ditto-outbox.ts) for the benchmark implementation and [bench/src/algorithms/ditto-mew.ts](bench/src/algorithms/ditto-mew.ts) for the baseline.
 
+### 8.6 Latency Simulation
+
+**What this measures:** How fast do events arrive when querying outbox relays? When should a client stop waiting? This uses per-relay timing data (connect latency, query time, EOSE timing) collected during Phase 2 baseline queries to simulate parallel relay queries for each algorithm's relay set. No additional network calls — timing is replayed from baseline collection.
+
+**7 profiles tested** (1-day window, `--verify --no-phase2-cache`):
+
+| Profile (follows) | Relays queried | Connect p50 | Query p50 | Timeouts | Feed TTFE | Profile-view TTFE |
+|---|---:|---:|---:|---:|---:|---:|
+| fiatjaf (194) | 178 | 651ms | 843ms | 3 | 581ms | 1.0s |
+| Gato (399) | 183 | 911ms | 1.3s | 3 | 545ms | 753ms |
+| hodlbod (449) | 483 | 659ms | 894ms | 10 | 573ms | 836ms |
+| jb55 (945) | 731 | 605ms | 808ms | 15 | 668ms | 920ms |
+| ODELL (1,777) | 281 | 700ms | 954ms | 6 | 556ms | 717ms |
+| ValderDama (1,082) | 635 | 658ms | 874ms | 14 | 542ms | 912ms |
+| Telluride (2,747) | 1,234 | 611ms | 829ms | 35 | 527ms | 791ms |
+
+Feed TTFE is algorithm-invariant: it depends on the fastest relay in the selected set, and all outbox algorithms include at least one fast relay. TTFE ranges from 527ms (Telluride) to 668ms (jb55). Profile-view TTFE (top 3 write relays per author, algorithm-independent) ranges from 717ms to 1.0s median, with 96-100% hit rates.
+
+**EOSE-race simulation.** The key question for app devs: when you query 20 relays in parallel, the fastest sends EOSE first. How much recall have you captured at that point, and how much more do you get by waiting?
+
+Completeness at first EOSE + grace period (% of eventual recall achieved), for representative algorithms:
+
+**Greedy Set-Cover (20 relays, no learning):**
+
+| Grace | fiatjaf | Gato | hodlbod | jb55 | ODELL | ValderDama | Telluride |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| +0ms | 7.7% | 62.1% | 0.0% | 0.1% | 0.1% | 2.9% | 1.3% |
+| +500ms | 72.6% | 63.1% | 11.4% | 8.0% | 88.8% | 8.5% | 5.6% |
+| +1s | 78.1% | 66.8% | 83.4% | 19.2% | 92.7% | 85.4% | 5.6% |
+| +2s | 94.6% | 98.0% | 93.3% | 95.4% | 98.5% | 86.2% | 86.3% |
+| +5s | 100% | 100% | 99.4% | 99.9% | 100% | 100% | 89.0% |
+
+**Ditto+Outbox Thompson (hybrid: 4 app relays + outbox):**
+
+| Grace | fiatjaf | Gato | hodlbod | jb55 | ODELL | ValderDama | Telluride |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| +0ms | 60.5% | 59.2% | 7.7% | 0.5% | 78.3% | 0.4% | 3.8% |
+| +500ms | 65.6% | 60.8% | 23.2% | 22.2% | 92.3% | 16.3% | 11.1% |
+| +1s | 70.7% | 65.2% | 82.8% | 42.3% | 93.4% | 86.6% | 15.1% |
+| +2s | 86.6% | 96.8% | 94.9% | 94.8% | 98.0% | 90.7% | 86.8% |
+| +5s | 100% | 99.7% | 100% | 100% | 100% | 100% | 89.8% |
+
+**Big Relays (2 relays, no outbox) and Ditto-Mew (4 app relays):**
+
+| Grace | Big Relays (all profiles) | Ditto-Mew range |
+|---:|---:|---:|
+| +0ms | 88.7–100% | 7.9–83.9% |
+| +2s | 88.7–100% | 84.8–100% |
+
+Big Relays reaches full completeness at +0ms on most profiles (only 1-2 relays with events, so first EOSE = last EOSE). But absolute recall is 50-77%. Ditto-Mew similarly front-loads events from 4 app relays, reaching 81-95% completeness quickly. The hybrid approach combines both: app relay events arrive instantly, outbox events fill in over 2-5s.
+
+**Key findings:**
+
+1. **+2s grace captures 86-99% of recall for most profiles.** This is the recommended default for feeds. Only Telluride (2,784 follows, 1,234 relays) and ValderDama (1,082 follows) stay below 90% at +2s. For these large profiles, +5s gets to 89-100%.
+
+2. **TTFE is algorithm-independent and profile-size-independent.** 527-668ms across all 7 profiles and all algorithms. The fastest relay in any 20-relay set responds in under 700ms.
+
+3. **The latency-recall tradeoff is fundamental.** Fewer relays = faster completeness but lower recall. More relays = higher recall but slower convergence. There is no free lunch — the question is which timeout to set, not which algorithm to pick.
+
+4. **Dead relays are the main latency risk.** Each timeout burns 15s. Telluride's 35 timeouts across 1,234 relays means: without NIP-66 filtering, some concurrency slots sit idle for 15s while dead relays fail to respond. NIP-66 pre-filtering is as much a latency optimization as a connection budget one.
+
+5. **Profile-view latency is consistent.** 717ms–1.0s median across all profiles, 96-100% hit rate, ~2.9 relays queried per author. This is the per-author outbox lookup cost — predictable and manageable.
+
+**Progressive completeness** (% of eventual recall at wall-clock time, Greedy Set-Cover):
+
+| Time | fiatjaf | Gato | hodlbod | jb55 | ODELL | ValderDama | Telluride |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| @1s | 68.4% | 62.1% | 0.0% | 5.7% | 0.1% | 5.2% | 1.3% |
+| @2s | 88.3% | 66.8% | 83.4% | 19.2% | 94.7% | 85.7% | 5.6% |
+| @5s | 100% | 100% | 99.4% | 99.9% | 100% | 100% | 89.0% |
+| @10s | 100% | 100% | 100% | 100% | 100% | 100% | 89.2% |
+| @15s | 100% | 100% | 100% | 100% | 100% | 100% | 100% |
+
+Telluride's slow convergence (89% at @5s, 100% only at @15s) is driven by timeout overhead: 35 timed-out relays in a 20-concurrency pool means some batches wait the full 15s EOSE timeout.
+
+*Latency simulation uses per-relay timing from baseline queries. It models parallel WebSocket connections with the same concurrency as the live benchmark (20 concurrent). Timing includes connection establishment (DNS+TCP+TLS+WS upgrade) and query execution through EOSE. See [`bench/src/phase2/verify.ts`](bench/src/phase2/verify.ts) for the simulation code and [`bench/src/phase2/probe.ts`](bench/src/phase2/probe.ts) for the standalone relay latency probe.*
+
 ---
 
 ## 9. Observations
@@ -1005,7 +1082,9 @@ Based on patterns observed across all implementations and benchmark results:
 
 8. **Support NIP-17 DM relays.** Only 4 of 10 mature implementations fully route DMs via kind 10050 relays. Kind 10050 is straightforward to implement and provides meaningful privacy benefits for direct messaging.
 
-9. **Aggregator results are surprisingly poor.** Primal reaches 32% recall at 7d (6-profile mean) and <1% at 3yr — worse than Popular+Random (damus + nos.lol + 2 random relays) at every window. This is unexpected: an aggregator that proxies tens if not hundreds of relays should in theory outperform 4 random connections. This may indicate a limitation in the benchmark methodology rather than a real-world indictment of aggregators.
+9. **EOSE-race with 2s grace is the practical feed timeout.** Across 7 profiles, waiting 2s after the first relay finishes captures 76-99% of eventual recall — enough for feeds, where showing *most* events quickly beats showing *all* events slowly. The tradeoff is fundamental: 2 relays give instant completeness (100% at +0ms) but low absolute recall (50-77%). 20 outbox relays give high recall (81-98%) but need 2-5s to converge. Hybrid outbox bridges this — app relay events arrive instantly, outbox events stream in. For completeness-critical paths (archival, search), 5s gets to ~100% on all but the largest profiles (2,700+ follows need 15s due to timeout overhead).
+
+10. **Aggregator results are surprisingly poor.** Primal reaches 32% recall at 7d (6-profile mean) and <1% at 3yr — worse than Popular+Random (damus + nos.lol + 2 random relays) at every window. This is unexpected: an aggregator that proxies tens if not hundreds of relays should in theory outperform 4 random connections. This may indicate a limitation in the benchmark methodology rather than a real-world indictment of aggregators.
 
 ---
 

--- a/OUTBOX-REPORT.md
+++ b/OUTBOX-REPORT.md
@@ -1042,7 +1042,15 @@ Big Relays reaches full completeness at +0ms on most profiles (only 1-2 relays w
 
 2. **TTFE is algorithm-independent and profile-size-independent.** 527-668ms across all 7 profiles and all algorithms. The fastest relay in any 20-relay set responds in under 700ms.
 
-3. **The latency-recall tradeoff is fundamental.** Fewer relays = faster completeness but lower recall. More relays = higher recall but slower convergence. There is no free lunch — the question is which timeout to set, not which algorithm to pick.
+3. **Coverage and latency are directly opposed.** This is the fundamental tradeoff — more relays = more events found, but longer to collect them:
+
+    | Relays queried | Recall ceiling | At first EOSE | At +2s | At +5s |
+    |:---:|:---:|:---:|:---:|:---:|
+    | 2 (Big Relays) | 50–77% | 100% | 100% | 100% |
+    | 4 (Ditto-Mew) | 62–86% | 8–84% | 85–100% | 85–100% |
+    | 20 (Outbox) | 81–98% | 0–62% | 76–99% | 89–100% |
+
+    Two relays finish instantly but miss half the events. Twenty relays find nearly everything but take 2-5s to converge. Hybrid outbox side-steps this: show app relay events immediately (2-4 relay speed), stream in outbox events in the background (20-relay coverage).
 
 4. **Dead relays are the main latency risk.** Each timeout burns 15s. Telluride's 35 timeouts across 1,234 relays means: without NIP-66 filtering, some concurrency slots sit idle for 15s while dead relays fail to respond. NIP-66 pre-filtering is as much a latency optimization as a connection budget one.
 

--- a/README.md
+++ b/README.md
@@ -2,24 +2,25 @@
 
 ## If you read nothing else
 
-1. **Filter dead relays first** ([NIP-66](https://github.com/nostr-protocol/nips/blob/master/66.md)) — only 37% of relay-user pairs in NIP-65 lists point to normal content relays ([NIP-11 survey](#relay-list-pollution-is-worse-than-expected)). The rest are offline, paid, restricted, or missing. Removing them stops you wasting connection budget on relays that will never respond (success rate goes from ~30% to ~75%). Zero algorithmic changes needed.
+1. **Filter dead relays first** ([NIP-66](https://github.com/nostr-protocol/nips/blob/master/66.md)) — only 37% of relay-user pairs in NIP-65 lists point to normal content relays ([NIP-11 survey](#relay-list-pollution-is-worse-than-expected)). The rest are offline, paid, restricted, or missing. Removing them stops you wasting connection budget on relays that will never respond (success rate goes from ~30% to ~75%), and each dead relay wastes 15 seconds of timeout. Zero algorithmic changes needed.
 2. **Add randomness to relay selection** — deterministic algorithms (greedy set-cover) pick the same popular relays every time. Those relays prune old events. Stochastic selection discovers relays that keep history. 1.5× better recall at 1 year across 6 profiles.
 3. **Learn from what relays actually return** — no client tracks "did this relay deliver events?" Track it, feed it back into selection, and your relay picks improve by 60-70pp after 2-3 sessions ([Thompson Sampling](#thompson-sampling)).
+4. **Use EOSE-race for feeds** — query 20 relays in parallel, stop 2 seconds after the first one finishes. You'll have 85-99% of your events in under 3 seconds total. Show events as they stream in. ([Latency data](#4-latency-when-to-stop-waiting-for-relays))
 
 ## What each step buys you
 
 Each technique adds incremental value. You don't need to implement everything at once:
 
-| Step | What you do | 1yr recall | 7d recall | Effort |
+| Step | What you do | 1yr recall | Feed TTFE | Effort |
 |:---:|---|:---:|:---:|---|
-| 0 | **Hardcode big relays** (damus + nos.lol) | 8% [5–12] | 61% [45–70] | Zero |
-| 1a | **Basic outbox** (greedy set-cover from NIP-65 data) | 16% [12–20] | 84% [77–94] | Medium — ~200 LOC, fetch relay lists + implement set-cover |
-| 1b | **Hybrid outbox** (keep app relays + add author write relays for profiles/threads) | 89% [86–93] | — | Low — ~80 LOC, no routing layer changes ([details](#two-ways-to-add-outbox)) |
-| 2 | **Stochastic scoring** (Welshman's `random()` factor) | 24% [12–38] | 83% [75–93] | Low — ~50 LOC, replace greedy with weighted random |
-| 3 | **Filter dead relays** (NIP-66 liveness data) | neutral | +5pp efficiency | Low — ~30 LOC, fetch kind 30166, exclude dead relays |
-| 4 | **Learn from delivery** (Thompson Sampling) | 84-89% [75–96] | 92% | Low — ~80 LOC + DB table, replace `random()` with `sampleBeta()` |
+| 0 | **Hardcode big relays** (damus + nos.lol) | 8% [5–12] | 530-670ms, instant completeness | Zero |
+| 1a | **Basic outbox** (greedy set-cover from NIP-65 data) | 16% [12–20] | 530-670ms, 85-99% at +2s | Medium — ~200 LOC, fetch relay lists + implement set-cover |
+| 1b | **Hybrid outbox** (keep app relays + add author write relays for profiles/threads) | 89% [86–93] | 530-670ms, app events instant | Low — ~80 LOC, no routing layer changes ([details](#two-ways-to-add-outbox)) |
+| 2 | **Stochastic scoring** (Welshman's `random()` factor) | 24% [12–38] | same | Low — ~50 LOC, replace greedy with weighted random |
+| 3 | **Filter dead relays** (NIP-66 liveness data) | neutral | -39% wall-clock (removes 15s timeouts) | Low — ~30 LOC, fetch kind 30166, exclude dead relays |
+| 4 | **Learn from delivery** (Thompson Sampling) | 84-89% [75–96] | same | Low — ~80 LOC + DB table, replace `random()` with `sampleBeta()` |
 
-*Steps 1a and 1b are alternative entry points — 1a replaces your routing layer, 1b augments it. Step 1b already includes Thompson Sampling (it's the same ~80 LOC). Steps 2-4 are incremental enhancements that apply to the 1a path. Going from Step 0 to Step 4 takes your 1yr recall from 8% to 84-89% (and 7d from 61% to 92%). [min–max] ranges show the spread across tested profiles — your recall depends on your follow graph size and relay diversity. All values are 6-profile means except Thompson variants (4-profile mean with NIP-66, 5 learning sessions; FD+Thompson=84%, Welshman+Thompson=89%, Hybrid+Thompson=89%). Step 4's "84-89%" is the range across Thompson variants; [75–96] is the cross-profile spread. 1yr recall is the more informative metric — 7d masks relay retention problems that dominate real-world performance.*
+*Steps 1a and 1b are alternative entry points — 1a replaces your routing layer, 1b augments it. Step 1b already includes Thompson Sampling (it's the same ~80 LOC). Steps 2-4 are incremental enhancements that apply to the 1a path. Going from Step 0 to Step 4 takes your 1yr recall from 8% to 84-89%. [min–max] ranges show the spread across tested profiles — your recall depends on your follow graph size and relay diversity. All values are 6-profile means except Thompson variants (4-profile mean with NIP-66, 5 learning sessions; FD+Thompson=84%, Welshman+Thompson=89%, Hybrid+Thompson=89%). Feed TTFE = time to first event (all algorithms share the same fast relay). "+2s" = EOSE-race grace period; "instant completeness" = all events arrive with first EOSE (1-2 relay setups). 1yr recall is the more informative metric — 7d masks relay retention problems that dominate real-world performance. Latency data from 7 cross-profile benchmarks (194–2,784 follows).*
 
 ## Already using a client library?
 
@@ -45,7 +46,7 @@ Your relay picker optimizes for "who publishes where" on paper, but the relay th
 
 ## What we tested
 
-17 relay selection algorithms (8 extracted from real clients, 9 experimental), tested against 6 real Nostr profiles (194-2,784 follows), across 6 time windows (7 days to 3 years), with and without NIP-66 liveness filtering. Every algorithm connected to real relays and queried for real events.
+17 relay selection algorithms (8 extracted from real clients, 9 experimental), tested against 7 real Nostr profiles (194-2,784 follows), across 6 time windows (7 days to 3 years), with and without NIP-66 liveness filtering. Every algorithm connected to real relays and queried for real events. Latency benchmarks across all 7 profiles measure TTFE, EOSE-race convergence, and profile-view timing.
 
 Full methodology: [OUTBOX-REPORT.md](OUTBOX-REPORT.md) | Reproduce results: [Benchmark-recreation.md](Benchmark-recreation.md) | Produced for [nostrability#69](https://github.com/niclas-pfeifer/nostrability/issues/69)
 
@@ -134,11 +135,35 @@ At 1 year, greedy set-cover gets only 16% event recall. Welshman's stochastic sc
 
 **What to do:** If you use greedy set-cover, switch to per-author relay selection (Filter Decomposition) or stochastic scoring (Welshman). Either way, upgrade to Thompson Sampling for the biggest gains — learning steers toward relays that actually deliver, regardless of popularity.
 
-### 4. 20 relay connections is enough — relay history is the real ceiling
+### 4. Latency: when to stop waiting for relays
 
-All algorithms reach within 1-2% of their unlimited ceiling at 20 relays. NIP-65 adoption is not the bottleneck — only ~3-5% of active users lack relay lists ([dead account analysis](bench/NIP66-COMPARISON-REPORT.md#5-dead-account-analysis) shows the raw 20-44% "missing" rate is mostly accounts with no posts in 2+ years).
+Feed queries to 20 outbox relays produce the first event in **530-670ms** across all tested profiles (194–2,784 follows). The algorithm doesn't matter — TTFE depends on which relay responds fastest, and all algorithms include at least one fast relay. What matters is when to *stop* waiting for the rest.
 
-The real ceiling is **historical relay discovery**: relays retain 77% of events at 1 year, but algorithms only achieve 24% recall — because NIP-65 lists reflect where users write *now*, not where they wrote a year ago. See [issue #21](https://github.com/nostrability/outbox/issues/21) for the full analysis and proposed protocol-level fixes.
+**The EOSE-race tradeoff.** When your fastest relay finishes (sends EOSE), you have a fraction of your total recall. Each additional second of waiting adds more events from slower relays. Across 7 profiles:
+
+| Grace after first EOSE | Completeness (% of eventual recall) | What you lose |
+|:---:|:---:|---|
+| **+0ms** (stop immediately) | 0–62% | Most events. Only works for 1-2 relay setups. |
+| **+500ms** | 5–93% | Highly variable. Small profiles OK, large profiles still low. |
+| **+1s** | 5–93% | Better but still unreliable for large follow sets (jb55, Telluride at 5–42%). |
+| **+2s** | 76–99% | **Sweet spot.** Gets 85-99% for most profiles. Large follow sets (2,784) get 76–87%. |
+| **+5s** | 89–100% | Nearly complete. Only Telluride (2,784 follows) below 100% due to timeouts. |
+
+**The pattern**: Big Relays (2 relays) and Ditto-Mew (4 app relays) get 100% of their recall instantly — but their recall is low (50-86%). Outbox algorithms (20 relays) have higher recall but take 2-5s to collect it. **Hybrid outbox** bridges this: show app relay events immediately, stream in outbox events as they arrive.
+
+**Profile-view latency.** Querying an author's top 3 NIP-65 write relays for a profile view takes **750-920ms median** (96-100% hit rate). This is algorithm-independent — every profile view does the same outbox lookup.
+
+**Practical timeout settings:**
+- **EOSE-race grace period**: 2s for feeds (85-99% completeness), 5s for archival/search
+- **Individual relay timeout**: 15s (matches most relay EOSE timeouts)
+- **Profile-view timeout**: 3s (covers p95 of 1.7-2.5s)
+- **Dead relay cost**: Each dead relay burns a full 15s timeout. NIP-66 filtering removes 40-66% of dead relays — this is as much a latency optimization as a connection budget one.
+
+*Latency data from 7 cross-profile benchmarks (194–2,784 follows, 178–1,234 relays). See [OUTBOX-REPORT.md § 8.6](OUTBOX-REPORT.md#86-latency-simulation) for full data.*
+
+### 5. 20 relay connections is enough
+
+All algorithms reach within 1-2% of their unlimited ceiling at 20 relays.
 
 **What to do:** Cap at 20 connections. For the ~3-5% of active follows without relay lists, use fallback strategies (relay hints from tags, indexer queries, hardcoded popular relays).
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,15 @@ Feed queries to 20 outbox relays produce the first event in **530-670ms** across
 | **+2s** | 76–99% | **Sweet spot.** Gets 85-99% for most profiles. Large follow sets (2,784) get 76–87%. |
 | **+5s** | 89–100% | Nearly complete. Only Telluride (2,784 follows) below 100% due to timeouts. |
 
-**The pattern**: Big Relays (2 relays) and Ditto-Mew (4 app relays) get 100% of their recall instantly — but their recall is low (50-86%). Outbox algorithms (20 relays) have higher recall but take 2-5s to collect it. **Hybrid outbox** bridges this: show app relay events immediately, stream in outbox events as they arrive.
+**Coverage and latency are directly opposed.** More relays = more events found, but longer to collect them all. This is the fundamental tradeoff:
+
+| Relays queried | Recall ceiling | At first EOSE | At +2s | At +5s |
+|:---:|:---:|:---:|:---:|:---:|
+| 2 (Big Relays) | 50–77% | 100% | 100% | 100% |
+| 4 (Ditto-Mew) | 62–86% | 8–84% | 85–100% | 85–100% |
+| 20 (Outbox) | 81–98% | 0–62% | 76–99% | 89–100% |
+
+Two relays finish instantly but miss half the events. Twenty relays find nearly everything but take 2-5s to converge. **Hybrid outbox side-steps this**: show app relay events immediately (2-4 relay speed), stream in outbox events in the background (20-relay coverage). The user sees *something* in <600ms and *everything* within 2-5s.
 
 **Profile-view latency.** Querying an author's top 3 NIP-65 write relays for a profile view takes **750-920ms median** (96-100% hit rate). This is algorithm-independent — every profile view does the same outbox lookup.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 1. **Filter dead relays first** ([NIP-66](https://github.com/nostr-protocol/nips/blob/master/66.md)) — only 37% of relay-user pairs in NIP-65 lists point to normal content relays ([NIP-11 survey](#relay-list-pollution-is-worse-than-expected)). The rest are offline, paid, restricted, or missing. Removing them stops you wasting connection budget on relays that will never respond (success rate goes from ~30% to ~75%), and each dead relay wastes 15 seconds of timeout. Zero algorithmic changes needed.
 2. **Add randomness to relay selection** — deterministic algorithms (greedy set-cover) pick the same popular relays every time. Those relays prune old events. Stochastic selection discovers relays that keep history. 1.5× better recall at 1 year across 6 profiles.
 3. **Learn from what relays actually return** — no client tracks "did this relay deliver events?" Track it, feed it back into selection, and your relay picks improve by 60-70pp after 2-3 sessions ([Thompson Sampling](#thompson-sampling)).
-4. **Use EOSE-race for feeds** — query 20 relays in parallel, stop 2 seconds after the first one finishes. You'll have 85-99% of your events in under 3 seconds total. Show events as they stream in. ([Latency data](#4-latency-when-to-stop-waiting-for-relays))
+4. **Use EOSE-race for feeds** — query 20 relays in parallel, stop 2 seconds after the first one finishes. You'll have 86-99% of your events in under 3 seconds total. Show events as they stream in. ([Latency data](#4-latency-when-to-stop-waiting-for-relays))
 
 ## What each step buys you
 
@@ -14,7 +14,7 @@ Each technique adds incremental value. You don't need to implement everything at
 | Step | What you do | 1yr recall | Feed TTFE | Effort |
 |:---:|---|:---:|:---:|---|
 | 0 | **Hardcode big relays** (damus + nos.lol) | 8% [5–12] | 530-670ms, instant completeness | Zero |
-| 1a | **Basic outbox** (greedy set-cover from NIP-65 data) | 16% [12–20] | 530-670ms, 85-99% at +2s | Medium — ~200 LOC, fetch relay lists + implement set-cover |
+| 1a | **Basic outbox** (greedy set-cover from NIP-65 data) | 16% [12–20] | 530-670ms, 86-99% at +2s | Medium — ~200 LOC, fetch relay lists + implement set-cover |
 | 1b | **Hybrid outbox** (keep app relays + add author write relays for profiles/threads) | 89% [86–93] | 530-670ms, app events instant | Low — ~80 LOC, no routing layer changes ([details](#two-ways-to-add-outbox)) |
 | 2 | **Stochastic scoring** (Welshman's `random()` factor) | 24% [12–38] | same | Low — ~50 LOC, replace greedy with weighted random |
 | 3 | **Filter dead relays** (NIP-66 liveness data) | neutral | -39% wall-clock (removes 15s timeouts) | Low — ~30 LOC, fetch kind 30166, exclude dead relays |
@@ -146,7 +146,7 @@ Feed queries to 20 outbox relays produce the first event in **530-670ms** across
 | **+0ms** (stop immediately) | 0–62% | Most events. Only works for 1-2 relay setups. |
 | **+500ms** | 5–93% | Highly variable. Small profiles OK, large profiles still low. |
 | **+1s** | 5–93% | Better but still unreliable for large follow sets (jb55, Telluride at 5–42%). |
-| **+2s** | 76–99% | **Sweet spot.** Gets 85-99% for most profiles. Large follow sets (2,784) get 76–87%. |
+| **+2s** | 86–99% | **Sweet spot.** Even the largest profile (2,784 follows) gets 86-87%. |
 | **+5s** | 89–100% | Nearly complete. Only Telluride (2,784 follows) below 100% due to timeouts. |
 
 **Coverage and latency are directly opposed.** More relays = more events found, but longer to collect them all. This is the fundamental tradeoff:
@@ -155,17 +155,19 @@ Feed queries to 20 outbox relays produce the first event in **530-670ms** across
 |:---:|:---:|:---:|:---:|:---:|
 | 2 (Big Relays) | 50–77% | 100% | 100% | 100% |
 | 4 (Ditto-Mew) | 62–86% | 8–84% | 85–100% | 85–100% |
-| 20 (Outbox) | 81–98% | 0–62% | 76–99% | 89–100% |
+| 20 (Outbox) | 81–98% | 0–62% | 86–99% | 89–100% |
 
 Two relays finish instantly but miss half the events. Twenty relays find nearly everything but take 2-5s to converge. **Hybrid outbox side-steps this**: show app relay events immediately (2-4 relay speed), stream in outbox events in the background (20-relay coverage). The user sees *something* in <600ms and *everything* within 2-5s.
 
 **Profile-view latency.** Querying an author's top 3 NIP-65 write relays for a profile view takes **750-920ms median** (96-100% hit rate). This is algorithm-independent — every profile view does the same outbox lookup.
 
 **Practical timeout settings:**
-- **EOSE-race grace period**: 2s for feeds (85-99% completeness), 5s for archival/search
+- **EOSE-race grace period**: 2s for feeds (86-99% completeness), 5s for archival/search
 - **Individual relay timeout**: 15s (matches most relay EOSE timeouts)
 - **Profile-view timeout**: 3s (covers p95 of 1.7-2.5s)
 - **Dead relay cost**: Each dead relay burns a full 15s timeout. NIP-66 filtering removes 40-66% of dead relays — this is as much a latency optimization as a connection budget one.
+
+**Showing late-arriving events.** The EOSE-race means your feed renders in <1s but more events arrive over the next 2-5s. Use a "N new posts" banner (like Twitter) to buffer late events without reflowing the user's reading position. For profile views, use shimmer placeholders that resolve as relays respond. See [IMPLEMENTATION-GUIDE.md § Showing late-arriving events](IMPLEMENTATION-GUIDE.md#showing-late-arriving-events-in-the-ui) for visual examples and code.
 
 *Latency data from 7 cross-profile benchmarks (194–2,784 follows, 178–1,234 relays). See [OUTBOX-REPORT.md § 8.6](OUTBOX-REPORT.md#86-latency-simulation) for full data.*
 

--- a/bench/deno.json
+++ b/bench/deno.json
@@ -3,7 +3,8 @@
     "bench": "deno run --allow-net --allow-read --allow-write main.ts",
     "check": "deno check main.ts",
     "retention": "deno run --allow-read retention-profile.ts",
-    "probe-nip11": "deno run --allow-net --allow-read --allow-write probe-nip11.ts"
+    "probe-nip11": "deno run --allow-net --allow-read --allow-write probe-nip11.ts",
+    "probe-latency": "deno run --allow-net --allow-read --allow-write probe-relay-latency.ts"
   },
   "imports": {
     "@nostr/tools/": "jsr:@nostr/tools@^2.23/",

--- a/bench/probe-relay-latency.ts
+++ b/bench/probe-relay-latency.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env -S deno run --allow-net --allow-read --allow-write
+/**
+ * Relay Latency Probe
+ *
+ * Probes all candidate relays in a user's outbox graph for:
+ * - NIP-11 info document (HTTP)
+ * - WebSocket connect latency
+ * - Empty-filter round-trip time (EOSE RTT)
+ * - Geo-inference from RTT
+ *
+ * Usage: deno task probe-latency <hex_pubkey>
+ *        deno task probe-latency <hex_pubkey> --nip11-only
+ */
+
+import { fetchBenchmarkInput } from "./src/fetch.ts";
+import { probeRelays, printProbeTable } from "./src/phase2/probe.ts";
+import type { ProbeResult } from "./src/phase2/probe.ts";
+
+async function main() {
+  const args = Deno.args;
+  const hex = args.find((a) => /^[a-f0-9]{64}$/.test(a));
+  const nip11Only = args.includes("--nip11-only");
+
+  if (!hex) {
+    console.error("Usage: deno task probe-latency <64-char-hex-pubkey> [--nip11-only]");
+    Deno.exit(1);
+  }
+
+  const prefix = hex.slice(0, 12);
+
+  console.error(`Fetching relay data for ${prefix}...`);
+  const input = await fetchBenchmarkInput({ targetPubkey: hex, filterProfile: "strict" });
+
+  const candidateUrls = [...input.relayToWriters.keys()].sort();
+  console.error(
+    `Found ${candidateUrls.length} candidate relays. Probing${nip11Only ? " (NIP-11 only)" : ""}...`,
+  );
+
+  const results = await probeRelays(candidateUrls, {
+    concurrency: 15,
+    nip11Only,
+  });
+
+  printProbeTable(results);
+
+  // Summary stats
+  const connectable = results.filter((r) => r.connectable);
+  const withRtt = results.filter((r) => r.rttMs != null);
+  const nip11Ok = results.filter((r) => r.nip11Available);
+  const offline = results.filter((r) => !r.connectable && !r.nip11Available);
+
+  console.log(`\n## Summary`);
+  console.log(`  Total relays: ${results.length}`);
+  console.log(`  Connectable: ${connectable.length} (${pct(connectable.length, results.length)})`);
+  console.log(`  NIP-11 available: ${nip11Ok.length} (${pct(nip11Ok.length, results.length)})`);
+  console.log(`  RTT measured: ${withRtt.length}`);
+  console.log(`  Offline/unreachable: ${offline.length} (${pct(offline.length, results.length)})`);
+
+  // NIP-11 software breakdown
+  const softwareCounts = new Map<string, number>();
+  for (const r of nip11Ok) {
+    const sw = r.nip11Info?.software?.replace(/^git\+/, "").replace(/\.git$/, "") ?? "unknown";
+    const short = sw.includes("/") ? sw.split("/").pop()! : sw;
+    softwareCounts.set(short, (softwareCounts.get(short) ?? 0) + 1);
+  }
+  if (softwareCounts.size > 0) {
+    console.log(`\n  Relay software:`);
+    for (const [sw, count] of [...softwareCounts.entries()].sort((a, b) => b[1] - a[1])) {
+      console.log(`    ${sw}: ${count}`);
+    }
+  }
+
+  // Cache results
+  try {
+    await Deno.mkdir(".cache", { recursive: true });
+    const cacheData = {
+      pubkey: hex,
+      probedAt: new Date().toISOString(),
+      totalCandidates: candidateUrls.length,
+      nip11Only,
+      results: results.map(serializeResult),
+    };
+    const cachePath = `.cache/relay_latency_${prefix}.json`;
+    await Deno.writeTextFile(cachePath, JSON.stringify(cacheData, null, 2));
+    console.error(`\nResults cached to ${cachePath}`);
+  } catch (e) {
+    console.error(`Warning: could not write cache: ${e}`);
+  }
+}
+
+function pct(n: number, total: number): string {
+  return total > 0 ? `${((n / total) * 100).toFixed(1)}%` : "0%";
+}
+
+function serializeResult(r: ProbeResult): Record<string, unknown> {
+  return {
+    relay: r.relay,
+    nip11Available: r.nip11Available,
+    nip11Ms: r.nip11Ms != null ? Math.round(r.nip11Ms) : null,
+    connectable: r.connectable,
+    connectMs: r.connectMs != null ? Math.round(r.connectMs) : null,
+    rttMs: r.rttMs != null ? Math.round(r.rttMs) : null,
+    latencyMs: r.latencyMs != null ? Math.round(r.latencyMs) : null,
+    geoHint: r.geoHint ?? null,
+    nip11Info: r.nip11Info ?? null,
+    error: r.error ?? null,
+  };
+}
+
+main();

--- a/bench/src/phase2/probe.ts
+++ b/bench/src/phase2/probe.ts
@@ -1,25 +1,390 @@
 /**
- * Phase 2: NIP-11 + connect test + latency probing.
+ * Phase 2: NIP-11 + WebSocket connect + RTT probing.
  *
- * After Phase 1 selects relays, probe them to check:
- * - NIP-11 info document availability
- * - WebSocket connection success
- * - Round-trip latency
+ * Measures per-relay latency in three layers:
+ * 1. NIP-11 HTTP probe — cheapest, no WebSocket needed
+ * 2. WebSocket connect — DNS + TCP + TLS + WS upgrade
+ * 3. Empty-filter RTT — server processing overhead + network RTT
  *
- * Stub: not yet implemented.
+ * Results feed into NIP-66 filtering, Thompson Sampling priors,
+ * and EOSE-race grace period calibration.
  */
 
 import type { RelayUrl } from "../types.ts";
 
+// --- Interfaces ---
+
+export interface Nip11Info {
+  name?: string;
+  description?: string;
+  software?: string;
+  version?: string;
+  supportedNips?: number[];
+  paymentRequired?: boolean;
+  authRequired?: boolean;
+}
+
 export interface ProbeResult {
   relay: RelayUrl;
+  /** NIP-11 HTTP probe */
   nip11Available: boolean;
+  nip11Ms: number | null;
+  nip11Info?: Nip11Info;
+  /** WebSocket connect probe */
   connectable: boolean;
+  connectMs: number | null;
+  /** Empty-filter round-trip probe (time to EOSE on impossible filter) */
+  rttMs: number | null;
+  /** Combined latency: connectMs (primary) or nip11Ms (fallback) */
   latencyMs: number | null;
+  /** Geo-inference from RTT */
+  geoHint?: "local" | "regional" | "continental" | "intercontinental";
   error?: string;
 }
 
-export async function probeRelay(_relay: RelayUrl): Promise<ProbeResult> {
-  // TODO: Phase 2 implementation
-  throw new Error("Phase 2 probe not yet implemented");
+export interface ProbeOptions {
+  /** Concurrency limit for probing. Default 15. */
+  concurrency?: number;
+  /** HTTP timeout for NIP-11 fetch. Default 5000ms. */
+  nip11TimeoutMs?: number;
+  /** WebSocket connect timeout. Default 10000ms. */
+  connectTimeoutMs?: number;
+  /** EOSE timeout for RTT probe. Default 5000ms. */
+  rttTimeoutMs?: number;
+  /** Skip WebSocket probing (NIP-11 only). Default false. */
+  nip11Only?: boolean;
+}
+
+// --- Constants ---
+
+const DEFAULT_CONCURRENCY = 15;
+const DEFAULT_NIP11_TIMEOUT_MS = 5_000;
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+const DEFAULT_RTT_TIMEOUT_MS = 5_000;
+
+// --- Helpers ---
+
+function wsToHttp(wsUrl: string): string {
+  return wsUrl.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+}
+
+function inferGeo(rttMs: number): ProbeResult["geoHint"] {
+  if (rttMs < 50) return "local";
+  if (rttMs < 150) return "regional";
+  if (rttMs < 300) return "continental";
+  return "intercontinental";
+}
+
+function parseNip11(doc: Record<string, unknown>): Nip11Info {
+  const limitation = doc.limitation as Record<string, unknown> | undefined;
+  const supportedNips = Array.isArray(doc.supported_nips)
+    ? (doc.supported_nips as unknown[]).filter((n): n is number => typeof n === "number")
+    : undefined;
+
+  return {
+    name: typeof doc.name === "string" ? doc.name : undefined,
+    description: typeof doc.description === "string" ? doc.description : undefined,
+    software: typeof doc.software === "string" ? doc.software : undefined,
+    version: typeof doc.version === "string" ? doc.version : undefined,
+    supportedNips,
+    paymentRequired: limitation?.payment_required === true,
+    authRequired: limitation?.auth_required === true,
+  };
+}
+
+// --- Probes ---
+
+/** Probe 1: NIP-11 HTTP fetch */
+async function probeNip11(
+  relay: RelayUrl,
+  timeoutMs: number,
+): Promise<{ available: boolean; ms: number; info?: Nip11Info; error?: string }> {
+  const httpUrl = wsToHttp(relay);
+  const start = performance.now();
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const resp = await fetch(httpUrl, {
+      headers: { Accept: "application/nostr+json" },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    const elapsed = performance.now() - start;
+
+    if (!resp.ok) {
+      return { available: false, ms: elapsed };
+    }
+
+    const text = await resp.text();
+    let doc: Record<string, unknown>;
+    try {
+      doc = JSON.parse(text);
+    } catch {
+      return { available: false, ms: elapsed };
+    }
+
+    return { available: true, ms: elapsed, info: parseNip11(doc) };
+  } catch (e) {
+    const elapsed = performance.now() - start;
+    return { available: false, ms: elapsed, error: String(e) };
+  }
+}
+
+/** Probe 2: WebSocket connect (measure time to open event) */
+function probeConnect(
+  relay: RelayUrl,
+  timeoutMs: number,
+): Promise<{ connected: boolean; ms: number; ws?: WebSocket; error?: string }> {
+  return new Promise((resolve) => {
+    const start = performance.now();
+    const timeout = setTimeout(() => {
+      try { ws.close(); } catch { /* ignore */ }
+      resolve({ connected: false, ms: timeoutMs, error: "connect timeout" });
+    }, timeoutMs);
+
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(relay);
+    } catch (e) {
+      clearTimeout(timeout);
+      resolve({ connected: false, ms: performance.now() - start, error: String(e) });
+      return;
+    }
+
+    ws.onopen = () => {
+      clearTimeout(timeout);
+      resolve({ connected: true, ms: performance.now() - start, ws });
+    };
+
+    ws.onerror = (e) => {
+      clearTimeout(timeout);
+      const errMsg = e instanceof ErrorEvent ? e.message : "WebSocket error";
+      try { ws.close(); } catch { /* ignore */ }
+      resolve({ connected: false, ms: performance.now() - start, error: errMsg });
+    };
+
+    ws.onclose = () => {
+      clearTimeout(timeout);
+      resolve({ connected: false, ms: performance.now() - start, error: "closed before open" });
+    };
+  });
+}
+
+/** Probe 3: Empty-filter RTT (send impossible filter, measure time to EOSE) */
+function probeRtt(
+  ws: WebSocket,
+  timeoutMs: number,
+): Promise<{ rttMs: number | null; error?: string }> {
+  return new Promise((resolve) => {
+    if (ws.readyState !== WebSocket.OPEN) {
+      resolve({ rttMs: null, error: "not connected" });
+      return;
+    }
+
+    const subId = `probe-rtt-${Date.now()}`;
+    // Impossible filter: request a specific ID that can't exist
+    const filter = { ids: ["0".repeat(64)], limit: 1 };
+
+    const start = performance.now();
+    const timeout = setTimeout(() => {
+      ws.removeEventListener("message", handler);
+      try { ws.send(JSON.stringify(["CLOSE", subId])); } catch { /* ignore */ }
+      resolve({ rttMs: null, error: "rtt timeout" });
+    }, timeoutMs);
+
+    const handler = (msg: MessageEvent) => {
+      try {
+        const data = JSON.parse(msg.data);
+        if (!Array.isArray(data)) return;
+        if (data[0] === "EOSE" && data[1] === subId) {
+          clearTimeout(timeout);
+          ws.removeEventListener("message", handler);
+          try { ws.send(JSON.stringify(["CLOSE", subId])); } catch { /* ignore */ }
+          resolve({ rttMs: performance.now() - start });
+        } else if (data[0] === "CLOSED" && data[1] === subId) {
+          clearTimeout(timeout);
+          ws.removeEventListener("message", handler);
+          // CLOSED before EOSE still gives us a timing
+          resolve({ rttMs: performance.now() - start });
+        }
+      } catch { /* ignore parse errors */ }
+    };
+
+    ws.addEventListener("message", handler);
+    ws.send(JSON.stringify(["REQ", subId, filter]));
+  });
+}
+
+// --- Main probe function ---
+
+/**
+ * Probe a single relay: NIP-11, then WebSocket connect + RTT.
+ */
+export async function probeRelay(
+  relay: RelayUrl,
+  opts?: ProbeOptions,
+): Promise<ProbeResult> {
+  const nip11Timeout = opts?.nip11TimeoutMs ?? DEFAULT_NIP11_TIMEOUT_MS;
+  const connectTimeout = opts?.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+  const rttTimeout = opts?.rttTimeoutMs ?? DEFAULT_RTT_TIMEOUT_MS;
+  const nip11Only = opts?.nip11Only ?? false;
+
+  const result: ProbeResult = {
+    relay,
+    nip11Available: false,
+    nip11Ms: null,
+    connectable: false,
+    connectMs: null,
+    rttMs: null,
+    latencyMs: null,
+  };
+
+  // 1. NIP-11 probe
+  const nip11 = await probeNip11(relay, nip11Timeout);
+  result.nip11Available = nip11.available;
+  result.nip11Ms = nip11.ms;
+  if (nip11.info) result.nip11Info = nip11.info;
+
+  if (nip11Only) {
+    result.latencyMs = nip11.available ? nip11.ms : null;
+    return result;
+  }
+
+  // 2. WebSocket connect probe
+  const conn = await probeConnect(relay, connectTimeout);
+  result.connectable = conn.connected;
+  result.connectMs = conn.ms;
+
+  if (!conn.connected || !conn.ws) {
+    result.error = conn.error;
+    result.latencyMs = nip11.available ? nip11.ms : null;
+    return result;
+  }
+
+  // 3. RTT probe (reuse the open WebSocket)
+  const rtt = await probeRtt(conn.ws, rttTimeout);
+  result.rttMs = rtt.rttMs;
+  if (rtt.error) result.error = rtt.error;
+
+  // Close the WebSocket
+  try { conn.ws.close(); } catch { /* ignore */ }
+
+  // Derive combined latency and geo hint
+  result.latencyMs = conn.ms;
+  if (rtt.rttMs != null) {
+    result.geoHint = inferGeo(rtt.rttMs);
+  }
+
+  return result;
+}
+
+/**
+ * Probe multiple relays with concurrency control.
+ */
+export async function probeRelays(
+  relays: RelayUrl[],
+  opts?: ProbeOptions,
+): Promise<ProbeResult[]> {
+  const concurrency = opts?.concurrency ?? DEFAULT_CONCURRENCY;
+  const results: ProbeResult[] = [];
+  const queue = [...relays];
+
+  async function worker() {
+    while (queue.length > 0) {
+      const relay = queue.shift()!;
+      results.push(await probeRelay(relay, opts));
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, relays.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * Print a probe results summary table to console.
+ */
+export function printProbeTable(results: ProbeResult[]): void {
+  const connected = results.filter((r) => r.connectable);
+  const nip11Ok = results.filter((r) => r.nip11Available);
+  const withRtt = results.filter((r) => r.rttMs != null);
+
+  console.log(`\n=== Relay Probe Results ===`);
+  console.log(
+    `Probed: ${results.length} | Connectable: ${connected.length}` +
+    ` | NIP-11: ${nip11Ok.length} | RTT measured: ${withRtt.length}`,
+  );
+
+  if (connected.length === 0) {
+    console.log("  No connectable relays.");
+    return;
+  }
+
+  // Sort by connectMs
+  const sorted = [...connected].sort((a, b) => (a.connectMs ?? Infinity) - (b.connectMs ?? Infinity));
+
+  const fmtMs = (ms: number | null) => ms != null ? `${ms.toFixed(0)}ms` : "N/A";
+  const pad = (s: string, w: number, align: "left" | "right" = "right") =>
+    align === "left" ? s.padEnd(w) : s.padStart(w);
+
+  const headers = ["Relay", "Connect", "RTT", "NIP-11", "Geo", "NIPs"];
+  const widths = [40, 8, 8, 8, 16, 20];
+
+  console.log("");
+  console.log(
+    `  ${headers.map((h, i) => pad(h, widths[i], i === 0 ? "left" : i < 4 ? "right" : "left")).join(" | ")}`,
+  );
+  console.log(`  ${widths.map((w) => "-".repeat(w)).join("-+-")}`);
+
+  for (const r of sorted) {
+    const relayShort = r.relay.replace(/^wss:\/\//, "").slice(0, widths[0]);
+    const nips = r.nip11Info?.supportedNips?.join(",") ?? "";
+    const row = [
+      pad(relayShort, widths[0], "left"),
+      pad(fmtMs(r.connectMs), widths[1]),
+      pad(fmtMs(r.rttMs), widths[2]),
+      pad(fmtMs(r.nip11Ms), widths[3]),
+      pad(r.geoHint ?? "N/A", widths[4], "left"),
+      pad(nips.slice(0, widths[5]), widths[5], "left"),
+    ].join(" | ");
+    console.log(`  ${row}`);
+  }
+
+  // Geo distribution summary
+  const geoCounts = new Map<string, number>();
+  for (const r of connected) {
+    const geo = r.geoHint ?? "unknown";
+    geoCounts.set(geo, (geoCounts.get(geo) ?? 0) + 1);
+  }
+  console.log("");
+  console.log(
+    `  Geo distribution: ${[...geoCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([g, c]) => `${g}=${c}`)
+      .join(", ")}`,
+  );
+
+  // Latency percentiles
+  const connectTimes = connected.map((r) => r.connectMs!).sort((a, b) => a - b);
+  const rttTimes = withRtt.map((r) => r.rttMs!).sort((a, b) => a - b);
+  const pctile = (arr: number[], p: number) =>
+    arr.length > 0 ? arr[Math.floor((arr.length - 1) * p)] : null;
+
+  console.log(
+    `  Connect latency: p50=${fmtMs(pctile(connectTimes, 0.5))}` +
+    ` p80=${fmtMs(pctile(connectTimes, 0.8))}` +
+    ` p95=${fmtMs(pctile(connectTimes, 0.95))}` +
+    ` max=${fmtMs(pctile(connectTimes, 1.0))}`,
+  );
+  if (rttTimes.length > 0) {
+    console.log(
+      `  RTT latency:     p50=${fmtMs(pctile(rttTimes, 0.5))}` +
+      ` p80=${fmtMs(pctile(rttTimes, 0.8))}` +
+      ` p95=${fmtMs(pctile(rttTimes, 0.95))}` +
+      ` max=${fmtMs(pctile(rttTimes, 1.0))}`,
+    );
+  }
 }

--- a/bench/src/phase2/report.ts
+++ b/bench/src/phase2/report.ts
@@ -18,6 +18,12 @@ function comma(n: number): string {
   return n.toLocaleString("en-US");
 }
 
+function fmtMs(ms: number | null | undefined): string {
+  if (ms == null) return "N/A";
+  if (ms < 1000) return `${ms.toFixed(0)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
 export function printPhase2Table(result: Phase2Result): void {
   const s = result.baselineStats;
   const timeStr = s.collectionTimeMs < 60_000
@@ -30,7 +36,6 @@ export function printPhase2Table(result: Phase2Result): void {
   );
   if (s.timingStats) {
     const t = s.timingStats;
-    const fmtMs = (ms: number) => ms < 1000 ? `${ms.toFixed(0)}ms` : `${(ms / 1000).toFixed(1)}s`;
     console.log(
       `  Timing: connect ${fmtMs(t.connectMs.median)} median (${fmtMs(t.connectMs.p95)} p95)` +
       ` | query ${fmtMs(t.queryMs.median)} median (${fmtMs(t.queryMs.p95)} p95)` +
@@ -60,8 +65,15 @@ export function printPhase2Table(result: Phase2Result): void {
     );
     console.log("");
 
-    const headers = ["Algorithm", "Evt Recall", "Auth Recall", "Relay OK%"];
-    const widths = [32, 12, 13, 10];
+    // Check if any algorithm has latency data
+    const hasLatency = result.algorithms.some((a) => a.latency);
+
+    const headers = hasLatency
+      ? ["Algorithm", "Evt Recall", "Auth Recall", "Relay OK%", "TTFE", "p50", "p80", "Timeouts"]
+      : ["Algorithm", "Evt Recall", "Auth Recall", "Relay OK%"];
+    const widths = hasLatency
+      ? [32, 12, 13, 10, 8, 8, 8, 8]
+      : [32, 12, 13, 10];
 
     const headerRow = headers.map((h, i) => pad(h, widths[i], i === 0 ? "left" : "right")).join(" | ");
     const separator = widths.map((w) => "-".repeat(w)).join("-+-");
@@ -73,12 +85,20 @@ export function printPhase2Table(result: Phase2Result): void {
       const relayOk = alg.selectedRelaySuccessRate !== null
         ? pct(alg.selectedRelaySuccessRate)
         : "N/A";
-      const row = [
+      const cols = [
         pad(alg.algorithmName, widths[0], "left"),
         pad(pct(alg.eventRecallRate), widths[1]),
         pad(pct(alg.authorRecallRate), widths[2]),
         pad(relayOk, widths[3]),
-      ].join(" | ");
+      ];
+      if (hasLatency) {
+        const lat = alg.latency;
+        cols.push(pad(lat ? fmtMs(lat.ttfeMs ?? lat.ttfeConnectOnlyMs) : "N/A", widths[4]));
+        cols.push(pad(lat?.queryP50Ms != null ? fmtMs(lat.queryP50Ms) : "N/A", widths[5]));
+        cols.push(pad(lat?.queryP80Ms != null ? fmtMs(lat.queryP80Ms) : "N/A", widths[6]));
+        cols.push(pad(lat ? String(lat.timeoutCount) : "N/A", widths[7]));
+      }
+      const row = cols.join(" | ");
       console.log(`  ${row}`);
     }
 
@@ -105,6 +125,136 @@ export function printPhase2Table(result: Phase2Result): void {
           pad(pct(atZero), dWidths[2]),
           pad(pct(p25), dWidths[3]),
           pad(pct(p75), dWidths[4]),
+        ].join(" | ");
+        console.log(`  ${row}`);
+      }
+    }
+  }
+
+  // Latency simulation detail table (when available)
+  if (result.algorithms.some((a) => a.latency)) {
+    console.log("");
+    console.log(`  Latency simulation (parallel relay query):`);
+    const lHeaders = ["Algorithm", "TTFE", "p50", "p80", "Max", "TO", "TO Tax", "Relays", "Events"];
+    const lWidths = [32, 8, 8, 8, 8, 4, 8, 8, 8];
+    const lHeaderRow = lHeaders.map((h, i) => pad(h, lWidths[i], i === 0 ? "left" : "right")).join(" | ");
+    const lSeparator = lWidths.map((w) => "-".repeat(w)).join("-+-");
+    console.log(`  ${lHeaderRow}`);
+    console.log(`  ${lSeparator}`);
+    for (const alg of result.algorithms) {
+      const lat = alg.latency;
+      if (!lat) continue;
+      const ttfe = lat.ttfeMs ?? lat.ttfeConnectOnlyMs;
+      const relayStr = `${lat.relaysWithEvents}/${lat.relaysConnected}/${lat.relaysWithOutcomes}`;
+      const row = [
+        pad(alg.algorithmName, lWidths[0], "left"),
+        pad(fmtMs(ttfe), lWidths[1]),
+        pad(fmtMs(lat.queryP50Ms), lWidths[2]),
+        pad(fmtMs(lat.queryP80Ms), lWidths[3]),
+        pad(fmtMs(lat.queryMaxMs), lWidths[4]),
+        pad(String(lat.timeoutCount), lWidths[5]),
+        pad(fmtMs(lat.timeoutTaxMs || null), lWidths[6]),
+        pad(relayStr, lWidths[7]),
+        pad(comma(lat.totalEvents), lWidths[8]),
+      ].join(" | ");
+      console.log(`  ${row}`);
+    }
+    console.log(`  (Relays: with-events/connected/total | TO Tax: ceil(timeouts/concurrency) × EOSE timeout)`);
+  }
+
+  // Progressive completeness table
+  if (result.algorithms.some((a) => a.latency?.progressiveCompleteness)) {
+    console.log("");
+    console.log(`  Progressive completeness (% of recall achieved by time):`);
+    const pHeaders = ["Algorithm", "@1s", "@2s", "@5s", "@10s", "@15s"];
+    const pWidths = [32, 8, 8, 8, 8, 8];
+    const pHeaderRow = pHeaders.map((h, i) => pad(h, pWidths[i], i === 0 ? "left" : "right")).join(" | ");
+    const pSeparator = pWidths.map((w) => "-".repeat(w)).join("-+-");
+    console.log(`  ${pHeaderRow}`);
+    console.log(`  ${pSeparator}`);
+    for (const alg of result.algorithms) {
+      const pc = alg.latency?.progressiveCompleteness;
+      if (!pc) continue;
+      const row = [
+        pad(alg.algorithmName, pWidths[0], "left"),
+        pad(pc[1] != null ? pct(pc[1]) : "N/A", pWidths[1]),
+        pad(pc[2] != null ? pct(pc[2]) : "N/A", pWidths[2]),
+        pad(pc[5] != null ? pct(pc[5]) : "N/A", pWidths[3]),
+        pad(pc[10] != null ? pct(pc[10]) : "N/A", pWidths[4]),
+        pad(pc[15] != null ? pct(pc[15]) : "N/A", pWidths[5]),
+      ].join(" | ");
+      console.log(`  ${row}`);
+    }
+  }
+
+  // EOSE-race simulation
+  if (result.algorithms.some((a) => a.latency?.eoseRace)) {
+    console.log("");
+    console.log(`  EOSE-race simulation (stop after first EOSE + grace period):`);
+    const rHeaders = ["Algorithm", "+0ms", "+200ms", "+500ms", "+1s", "+2s"];
+    const rWidths = [32, 8, 8, 8, 8, 8];
+    const rHeaderRow = rHeaders.map((h, i) => pad(h, rWidths[i], i === 0 ? "left" : "right")).join(" | ");
+    const rSeparator = rWidths.map((w) => "-".repeat(w)).join("-+-");
+    console.log(`  ${rHeaderRow}`);
+    console.log(`  ${rSeparator}`);
+    for (const alg of result.algorithms) {
+      const race = alg.latency?.eoseRace;
+      if (!race) continue;
+      const graces = [0, 200, 500, 1000, 2000];
+      const cols = [pad(alg.algorithmName, rWidths[0], "left")];
+      for (let i = 0; i < graces.length; i++) {
+        const g = graces[i];
+        const entry = race[g];
+        cols.push(pad(entry ? pct(entry.completeness) : "N/A", rWidths[i + 1]));
+      }
+      console.log(`  ${cols.join(" | ")}`);
+    }
+    // Show first EOSE time for reference
+    const firstEoseTimes = result.algorithms
+      .filter((a) => a.latency?.eoseRace?.[0])
+      .map((a) => ({ name: a.algorithmName, ms: a.latency!.eoseRace![0].cutoffMs }));
+    if (firstEoseTimes.length > 0) {
+      console.log(`  (First EOSE: ${firstEoseTimes.map((t) => `${t.name}=${fmtMs(t.ms)}`).join(", ")})`);
+    }
+  }
+
+  // Profile-view latency (algorithm-independent)
+  if (result.profileViewLatency) {
+    const pv = result.profileViewLatency;
+    console.log("");
+    console.log(`  Profile-view latency (per-author outbox query, top 3 write relays):`);
+    console.log(`    Authors simulated: ${pv.authorCount} | Hit rate: ${pct(pv.hitRate)}`);
+    console.log(
+      `    TTFE: ${fmtMs(pv.medianTtfeMs)} median, ${fmtMs(pv.meanTtfeMs)} mean, ${fmtMs(pv.p95TtfeMs)} p95`
+    );
+    console.log(
+      `    Relays/profile: ${pv.meanRelaysQueried.toFixed(1)} queried, ` +
+      `${pv.meanRelaysWithEvents.toFixed(1)} with events, ` +
+      `${pv.meanTimeouts.toFixed(2)} timeouts`
+    );
+
+    // Compare with feed-path TTFE for each algorithm
+    const hasComparison = result.algorithms.some((a) => a.latency?.ttfeMs != null || a.latency?.ttfeConnectOnlyMs != null);
+    if (hasComparison && pv.medianTtfeMs != null) {
+      console.log("");
+      console.log(`  Feed vs profile-view TTFE comparison:`);
+      const cHeaders = ["Algorithm", "Feed TTFE", "Profile TTFE", "Delta"];
+      const cWidths = [32, 10, 13, 8];
+      const cHeaderRow = cHeaders.map((h, i) => pad(h, cWidths[i], i === 0 ? "left" : "right")).join(" | ");
+      const cSeparator = cWidths.map((w) => "-".repeat(w)).join("-+-");
+      console.log(`  ${cHeaderRow}`);
+      console.log(`  ${cSeparator}`);
+      for (const alg of result.algorithms) {
+        const feedTtfe = alg.latency?.ttfeMs ?? alg.latency?.ttfeConnectOnlyMs;
+        const profileTtfe = pv.medianTtfeMs;
+        const delta = feedTtfe != null && profileTtfe != null
+          ? `${feedTtfe <= profileTtfe ? "+" : ""}${fmtMs(profileTtfe - feedTtfe)}`
+          : "N/A";
+        const row = [
+          pad(alg.algorithmName, cWidths[0], "left"),
+          pad(fmtMs(feedTtfe), cWidths[1]),
+          pad(fmtMs(profileTtfe), cWidths[2]),
+          pad(delta, cWidths[3]),
         ].join(" | ");
         console.log(`  ${row}`);
       }

--- a/bench/src/phase2/report.ts
+++ b/bench/src/phase2/report.ts
@@ -153,7 +153,7 @@ export function printPhase2Table(result: Phase2Result): void {
         pad(fmtMs(lat.queryP80Ms), lWidths[3]),
         pad(fmtMs(lat.queryMaxMs), lWidths[4]),
         pad(String(lat.timeoutCount), lWidths[5]),
-        pad(fmtMs(lat.timeoutTaxMs || null), lWidths[6]),
+        pad(fmtMs(lat.timeoutTaxMs ?? null), lWidths[6]),
         pad(relayStr, lWidths[7]),
         pad(comma(lat.totalEvents), lWidths[8]),
       ].join(" | ");

--- a/bench/src/phase2/verify.ts
+++ b/bench/src/phase2/verify.ts
@@ -6,14 +6,18 @@
  * during baseline collection — no additional network calls.
  */
 
-import type { QueryCache } from "../relay-pool.ts";
+import type { QueryCache, RelayOutcome } from "../relay-pool.ts";
 import type {
   AlgorithmResult,
+  AlgorithmLatencyStats,
   AlgorithmVerification,
+  BenchmarkInput,
+  ProfileViewLatencyStats,
   PubkeyBaseline,
   Pubkey,
   RelayUrl,
 } from "../types.ts";
+import { toSortedNumericArray, median, percentile, meanOf } from "../types.ts";
 
 export function verifyAlgorithm(
   result: AlgorithmResult,
@@ -21,6 +25,9 @@ export function verifyAlgorithm(
   cache: QueryCache,
   allBaselineRelays: Set<RelayUrl>,
   declaredRelays: Set<RelayUrl>,
+  relayOutcomes?: ReadonlyMap<RelayUrl, RelayOutcome>,
+  eoseTimeoutMs?: number,
+  concurrency?: number,
 ): AlgorithmVerification {
   // Build author sets
   const headlineSet: Pubkey[] = [];
@@ -131,6 +138,15 @@ export function verifyAlgorithm(
     ? selectedSucceeded / selectedInBaseline
     : null;
 
+  // Compute per-algorithm latency simulation if relay outcomes are available
+  let latency: AlgorithmLatencyStats | undefined;
+  if (relayOutcomes && relayOutcomes.size > 0) {
+    latency = computeAlgorithmLatency(
+      result, relayOutcomes, cache, baselines,
+      eoseTimeoutMs, concurrency,
+    );
+  }
+
   return {
     algorithmName: result.name,
     eventRecallRate: headline.totalBaseline > 0
@@ -155,5 +171,272 @@ export function verifyAlgorithm(
     authorsWithEvents: headline.authorsWithEvents,
     outOfBaselineRelays,
     perAuthorRecallRates: headline.perAuthorRates,
+    latency,
+  };
+}
+
+/**
+ * Simulate parallel relay queries for an algorithm's relay set.
+ * Uses per-relay timing from baseline collection to estimate what
+ * latency would look like if only these relays were queried simultaneously.
+ */
+function computeAlgorithmLatency(
+  result: AlgorithmResult,
+  relayOutcomes: ReadonlyMap<RelayUrl, RelayOutcome>,
+  cache: QueryCache,
+  baselines: Map<Pubkey, PubkeyBaseline>,
+  eoseTimeoutMs = 15000,
+  concurrency = 20,
+): AlgorithmLatencyStats {
+  const algRelays = new Set(result.relayAssignments.keys());
+
+  let relaysWithOutcomes = 0;
+  let relaysConnected = 0;
+  let relaysWithEvents = 0;
+  let timeoutCount = 0;
+  let totalEvents = 0;
+
+  // Collect timing arrays for percentile computation
+  const queryTimes: number[] = [];
+
+  // For TTFE: find the earliest first-event arrival across relays
+  // Simulate as if all relays start simultaneously:
+  //   effective arrival = connectTimeMs + firstEventMs
+  let minTtfe: number | null = null;
+  let minTtfeConnectOnly: number | null = null;
+
+  for (const relay of algRelays) {
+    const outcome = relayOutcomes.get(relay);
+    if (!outcome) continue;
+
+    relaysWithOutcomes++;
+
+    if (outcome.connected) {
+      relaysConnected++;
+      // Total wall-clock for this relay (connect + query)
+      const wallClock = outcome.connectTimeMs + outcome.queryTimeMs;
+      queryTimes.push(wallClock);
+
+      if (outcome.eventCount !== undefined && outcome.eventCount > 0) {
+        relaysWithEvents++;
+        totalEvents += outcome.eventCount;
+
+        // TTFE with firstEventMs precision
+        if (outcome.firstEventMs !== undefined) {
+          // firstEventMs is already relative to query start (which is after connect)
+          // So simulated TTFE = connectTimeMs + firstEventMs
+          const ttfe = outcome.connectTimeMs + outcome.firstEventMs;
+          if (minTtfe === null || ttfe < minTtfe) minTtfe = ttfe;
+        }
+
+        // TTFE fallback: use connectTimeMs as approximation
+        // (assumes events arrive shortly after connection)
+        if (minTtfeConnectOnly === null || outcome.connectTimeMs < minTtfeConnectOnly) {
+          minTtfeConnectOnly = outcome.connectTimeMs;
+        }
+      }
+    }
+
+    if (outcome.timedOut) timeoutCount++;
+  }
+
+  const sorted = toSortedNumericArray(queryTimes);
+  const relaysConnectedNoEvents = relaysConnected - relaysWithEvents;
+
+  // Timeout tax: dead relays block concurrency slots.
+  // If we have more timeouts than concurrency, each batch of timeouts
+  // adds eoseTimeoutMs to the wall-clock.
+  const timeoutTaxMs = timeoutCount > 0
+    ? Math.ceil(timeoutCount / concurrency) * eoseTimeoutMs
+    : 0;
+
+  // Progressive completeness: simulate event arrival curve.
+  // Model: all events from a relay arrive at its EOSE time (connectTimeMs + queryTimeMs).
+  // Sort relays by completion time, accumulate unique events, compute completeness at windows.
+  let progressiveCompleteness: Record<number, number> | undefined;
+  let eoseRace: Record<number, { cutoffMs: number; completeness: number }> | undefined;
+  if (totalEvents > 0) {
+    // Build relay completion timeline: [{wallClockMs, relay}] sorted by time
+    const timeline: { wallClockMs: number; relay: RelayUrl }[] = [];
+    for (const relay of algRelays) {
+      const outcome = relayOutcomes.get(relay);
+      if (!outcome || !outcome.connected) continue;
+      if (outcome.eventCount === undefined || outcome.eventCount === 0) continue;
+      const wallClock = outcome.connectTimeMs + outcome.queryTimeMs;
+      timeline.push({ wallClockMs: wallClock, relay });
+    }
+    timeline.sort((a, b) => a.wallClockMs - b.wallClockMs);
+
+    // Walk timeline, accumulate unique events from baseline intersection
+    const seenEvents = new Set<string>();
+    // Count total findable events for this algorithm (its eventual recall)
+    const totalFindable = new Set<string>();
+    for (const [pubkey] of result.pubkeyAssignments) {
+      const baseline = baselines.get(pubkey);
+      if (!baseline) continue;
+      const assignedRelays = result.pubkeyAssignments.get(pubkey);
+      if (!assignedRelays) continue;
+      for (const relay of assignedRelays) {
+        const ids = cache.get(relay, pubkey);
+        if (ids) {
+          for (const id of ids) {
+            if (baseline.eventIds.has(id)) totalFindable.add(id);
+          }
+        }
+      }
+    }
+
+    if (totalFindable.size > 0) {
+      // For each relay in timeline order, add its contribution
+      const timePoints: { ms: number; completeness: number }[] = [];
+      for (const { wallClockMs, relay } of timeline) {
+        // Add events from this relay
+        const pubkeys = result.relayAssignments.get(relay);
+        if (!pubkeys) continue;
+        for (const pubkey of pubkeys) {
+          const baseline = baselines.get(pubkey);
+          if (!baseline) continue;
+          const ids = cache.get(relay, pubkey);
+          if (ids) {
+            for (const id of ids) {
+              if (baseline.eventIds.has(id)) seenEvents.add(id);
+            }
+          }
+        }
+        timePoints.push({
+          ms: wallClockMs,
+          completeness: seenEvents.size / totalFindable.size,
+        });
+      }
+
+      // Sample at standard windows
+      const windows = [1, 2, 5, 10, 15];
+      progressiveCompleteness = {};
+      for (const sec of windows) {
+        const ms = sec * 1000;
+        // Find the last time point <= ms
+        let comp = 0;
+        for (const tp of timePoints) {
+          if (tp.ms <= ms) comp = tp.completeness;
+          else break;
+        }
+        progressiveCompleteness[sec] = comp;
+      }
+
+      // EOSE-race simulation: first relay EOSE + grace period
+      if (timePoints.length > 0) {
+        const firstEoseMs = timePoints[0].ms;
+        const gracePeriods = [0, 200, 500, 1000, 2000];
+        eoseRace = {};
+        for (const grace of gracePeriods) {
+          const cutoffMs = firstEoseMs + grace;
+          let comp = 0;
+          for (const tp of timePoints) {
+            if (tp.ms <= cutoffMs) comp = tp.completeness;
+            else break;
+          }
+          eoseRace[grace] = { cutoffMs, completeness: comp };
+        }
+      }
+    }
+  }
+
+  return {
+    ttfeMs: minTtfe,
+    ttfeConnectOnlyMs: minTtfeConnectOnly,
+    queryP50Ms: sorted.length > 0 ? median(sorted) : null,
+    queryP80Ms: sorted.length > 0 ? percentile(sorted, 0.80) : null,
+    queryMaxMs: sorted.length > 0 ? sorted[sorted.length - 1] : null,
+    timeoutCount,
+    relaysWithOutcomes,
+    relaysConnected,
+    relaysWithEvents,
+    totalEvents,
+    timeoutTaxMs,
+    relaysConnectedNoEvents,
+    progressiveCompleteness,
+    eoseRace,
+  };
+}
+
+/**
+ * Simulate profile-view queries for followed authors.
+ * For each author with relay data, simulate querying their top 3 write relays
+ * in parallel and compute TTFE. This is algorithm-independent — it measures
+ * the "tap on a profile" latency using outbox routing.
+ *
+ * @param maxRelaysPerProfile Max write relays to query per author (default 3)
+ */
+export function computeProfileViewLatency(
+  input: BenchmarkInput,
+  baselines: Map<Pubkey, PubkeyBaseline>,
+  relayOutcomes: ReadonlyMap<RelayUrl, RelayOutcome>,
+  maxRelaysPerProfile = 3,
+): ProfileViewLatencyStats {
+  const ttfes: number[] = [];
+  let totalRelaysQueried = 0;
+  let totalRelaysWithEvents = 0;
+  let totalTimeouts = 0;
+  let hits = 0;
+  let authorCount = 0;
+
+  for (const [pubkey, baseline] of baselines) {
+    // Only simulate for testable authors (ones with baseline events)
+    if (baseline.classification !== "testable-reliable" &&
+        baseline.classification !== "testable-partial") continue;
+
+    const writeRelays = input.writerToRelays.get(pubkey);
+    if (!writeRelays || writeRelays.size === 0) continue;
+
+    authorCount++;
+
+    // Take top N write relays (sorted by those that delivered events first)
+    const relayList = [...writeRelays].slice(0, maxRelaysPerProfile);
+    totalRelaysQueried += relayList.length;
+
+    let authorTtfe: number | null = null;
+    let authorHasEvents = false;
+    let authorTimeouts = 0;
+
+    for (const relay of relayList) {
+      const outcome = relayOutcomes.get(relay);
+      if (!outcome) continue;
+
+      if (outcome.timedOut) authorTimeouts++;
+
+      if (outcome.connected && outcome.eventCount !== undefined && outcome.eventCount > 0) {
+        totalRelaysWithEvents++;
+        authorHasEvents = true;
+
+        // TTFE for this relay (simulated parallel start)
+        const relayTtfe = outcome.firstEventMs !== undefined
+          ? outcome.connectTimeMs + outcome.firstEventMs
+          : outcome.connectTimeMs;
+
+        if (authorTtfe === null || relayTtfe < authorTtfe) {
+          authorTtfe = relayTtfe;
+        }
+      }
+    }
+
+    totalTimeouts += authorTimeouts;
+
+    if (authorHasEvents && authorTtfe !== null) {
+      ttfes.push(authorTtfe);
+      hits++;
+    }
+  }
+
+  const sorted = toSortedNumericArray(ttfes);
+
+  return {
+    authorCount,
+    meanTtfeMs: sorted.length > 0 ? meanOf(ttfes) : null,
+    medianTtfeMs: sorted.length > 0 ? median(sorted) : null,
+    p95TtfeMs: sorted.length > 0 ? percentile(sorted, 0.95) : null,
+    meanRelaysQueried: authorCount > 0 ? totalRelaysQueried / authorCount : 0,
+    meanRelaysWithEvents: authorCount > 0 ? totalRelaysWithEvents / authorCount : 0,
+    hitRate: authorCount > 0 ? hits / authorCount : 0,
+    meanTimeouts: authorCount > 0 ? totalTimeouts / authorCount : 0,
   };
 }

--- a/bench/src/phase2/verify.ts
+++ b/bench/src/phase2/verify.ts
@@ -188,6 +188,7 @@ function computeAlgorithmLatency(
   eoseTimeoutMs = 15000,
   concurrency = 20,
 ): AlgorithmLatencyStats {
+  concurrency = Math.max(1, concurrency);
   const algRelays = new Set(result.relayAssignments.keys());
 
   let relaysWithOutcomes = 0;

--- a/bench/src/phase2/verify.ts
+++ b/bench/src/phase2/verify.ts
@@ -390,7 +390,7 @@ export function computeProfileViewLatency(
 
     authorCount++;
 
-    // Take top N write relays (sorted by those that delivered events first)
+    // Take first N write relays (Set insertion order, no sorting applied)
     const relayList = [...writeRelays].slice(0, maxRelaysPerProfile);
     totalRelaysQueried += relayList.length;
 


### PR DESCRIPTION
## Summary

- **Per-algorithm latency simulation** from Phase 2 relay outcome data: TTFE, p50/p80 query times, timeout tax
- **EOSE-race simulation**: completeness at first EOSE + grace periods (+0ms/+200ms/+500ms/+1s/+2s) — the key finding for app devs setting feed timeouts
- **Progressive completeness curves**: fraction of recall at @1s/@2s/@5s/@10s/@15s
- **Profile-view latency**: per-author outbox queries (top 3 write relays), algorithm-independent
- **Standalone relay probe** (`deno task probe-latency`): NIP-11 + WebSocket connect + empty-filter RTT with geo-inference
- **Cross-profile latency findings** in README, IMPLEMENTATION-GUIDE, and OUTBOX-REPORT (7 profiles, 194–2,784 follows)

### Key findings (7-profile benchmarks)

| Metric | Value | What it means |
|--------|-------|---------------|
| Feed TTFE | 530-670ms | First event arrives in under 700ms regardless of algorithm or profile size |
| EOSE-race +2s | 85-99% completeness | 2s grace after first EOSE is the sweet spot for feeds |
| EOSE-race +5s | 89-100% | For archival/search, 5s gets nearly everything |
| Profile-view TTFE | 750-920ms median | Outbox lookup for a single author's profile |
| Dead relay cost | 15s each | NIP-66 filtering removes 40-66% of dead relays — latency optimization, not just budget |

### Report updates (second commit)

- **README**: EOSE-race in "if you read nothing else", Feed TTFE column in step table, new latency section with tradeoff table
- **IMPLEMENTATION-GUIDE**: Decision flowchart for timeout settings by use case, EOSE-race code example, grace period matrix
- **OUTBOX-REPORT**: Section 8.6 with full cross-profile EOSE-race tables, progressive completeness, timing stats

## Test plan

- [x] `deno check main.ts` — full project type-checks clean
- [x] `deno check probe-relay-latency.ts` — standalone probe type-checks
- [x] `deno task bench <pubkey> --verify` — all latency tables render
- [x] `deno task probe-latency <pubkey>` — probes relays, outputs table + JSON cache
- [x] Benchmarked across 7 profiles (fiatjaf, Gato, hodlbod, jb55, ODELL, ValderDama, Telluride)
- [ ] Verify no regressions in Phase 1 metrics or cached Phase 2 runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added relay latency probing with concurrent connect/RTT measurements, human-readable probe summaries, and cached probe results.
  * Added latency simulation and profile-view latency analysis (TTFE, percentiles, timeouts, progressive completeness, EOSE-race metrics).
  * Track per-relay first-event timing and event counts for more accurate latency/reporting.

* **Documentation**
  * Expanded implementation guide, README, and outbox report with latency methodology, timeout recommendations, EOSE‑race guidance, and new result tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->