### PR TITLE
Fix parent issue link URL

### DIFF
--- a/OUTBOX-REPORT.md
+++ b/OUTBOX-REPORT.md
@@ -6,7 +6,7 @@
 
 **An analysis of NIP-65 outbox/inbox relay routing across 15 Nostr clients and libraries**
 
-*Produced for [nostrability#69](https://github.com/niclas-pfeifer/nostrability/issues/69)*
+*Produced for [nostrability#69](https://github.com/nostrability/nostrability/issues/69)*
 
 *Benchmark data collected February 2026. Relay state changes continuously — results are a snapshot of network conditions at benchmark time. Relay availability, retention policies, and event counts will differ on re-run. Relative algorithm rankings should be stable; absolute recall percentages will vary.*
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Your relay picker optimizes for "who publishes where" on paper, but the relay th
 
 17 relay selection algorithms (8 extracted from real clients, 9 experimental), tested against 7 real Nostr profiles (194-2,784 follows), across 6 time windows (7 days to 3 years), with and without NIP-66 liveness filtering. Every algorithm connected to real relays and queried for real events. Latency benchmarks across all 7 profiles measure TTFE, EOSE-race convergence, and profile-view timing.
 
-Full methodology: [OUTBOX-REPORT.md](OUTBOX-REPORT.md) | Reproduce results: [Benchmark-recreation.md](Benchmark-recreation.md) | Produced for [nostrability#69](https://github.com/niclas-pfeifer/nostrability/issues/69)
+Full methodology: [OUTBOX-REPORT.md](OUTBOX-REPORT.md) | Reproduce results: [Benchmark-recreation.md](Benchmark-recreation.md) | Produced for [nostrability#69](https://github.com/nostrability/nostrability/issues/69)
 
 *Benchmark data collected February 2026. Relay state changes continuously — relative algorithm rankings should be stable; absolute recall percentages will vary on re-run.*
 
@@ -508,7 +508,7 @@ analysis/
 - [Implementation Guide](IMPLEMENTATION-GUIDE.md) — Detailed recommendations with code examples
 - [Cross-Client Comparison](analysis/cross-client-comparison.md) — How 15 clients make each decision
 - [Benchmark Recreation](Benchmark-recreation.md) — Reproduce all results
-- [nostrability#69](https://github.com/niclas-pfeifer/nostrability/issues/69) — Parent issue
+- [nostrability#69](https://github.com/nostrability/nostrability/issues/69) — Parent issue
 - [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) — Relay List Metadata specification
 - [Building Nostr](https://building-nostr.coracle.social) — Protocol architecture guide (relay routing, content migration, bootstrapping)
 - [replicatr](https://github.com/coracle-social/replicatr) — Event replication daemon for relay list changes (negentropy sync)


### PR DESCRIPTION
## Summary
- Fixed nostrability#69 links in README.md and OUTBOX-REPORT.md that incorrectly pointed to `niclas-pfeifer/nostrability` instead of `nostrability/nostrability`

## Test plan
- [ ] Verify links resolve to https://github.com/nostrability/nostrability/issues/69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external issue links and repository references in documentation files to reflect the new repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->