### PR TITLE
Add Voyage multi-phase relay selection benchmark

### DIFF
--- a/bench/phase-1-findings.md
+++ b/bench/phase-1-findings.md
@@ -61,6 +61,8 @@ Voyage's multi-phase algorithm uses `pubkeyCache` deduplication in Phase 1 — e
 
 **1yr event recall across 6 profiles (NIP-66 liveness filter):**
 
+Follow counts below reflect the contact-list snapshot at benchmark time (March 2026) and may differ from counts in the assignment-coverage table above, which used an earlier snapshot.
+
 | Profile | Follows | Voyage (5-13 relays) | Greedy @20 | Welshman @20 | Nostur @20 |
 |---------|--------:|---------------------:|-----------:|-------------:|-----------:|
 | fiatjaf | 194 | 6.4% | 28.8% | 32.8% | 27.3% |
@@ -91,7 +93,7 @@ This is a fundamental tradeoff: connecting to more relays increases recall but a
 - **Interactive navigation (tap on profile):** Minimize TTFE — connect to 2-3 relays, accept lower recall
 - **Hybrid:** Use more connections for feed, fewer for profile views
 
-No client currently adapts its connection budget per use case. Voyage's low connection count is better suited for interactive profile views than feed loading.
+None of the benchmarked clients in this study (as of March 2026) adapt their connection budget per use case. Voyage's low connection count is better suited for interactive profile views than feed loading.
 
 ## Client Mapping
 

--- a/bench/phase-1-findings.md
+++ b/bench/phase-1-findings.md
@@ -55,6 +55,44 @@ Direct Mapping                 | 69.1% | 69.6% | 71.6% | 71.6% | 71.6% | 72.7% |
 5. **NIP-65 adoption is the bottleneck.** Best algorithm vs ceiling gap: 1-3%. Missing relay lists: 20-44%.
 6. **Coverage vs concentration tradeoff.** Greedy packs onto few relays (Gini 0.77). Stochastic spreads load (0.51) at cost of lower coverage.
 
+### Voyage: Connection Budget vs 1yr Event Recall
+
+Voyage's multi-phase algorithm uses `pubkeyCache` deduplication in Phase 1 — each pubkey is assigned to exactly 1 relay before moving on. This means the top 5-13 relays absorb all follows, and the 25-connection budget goes mostly unused. The redundancy pass (Phase 4) adds second-relay coverage within those same relays but never opens new connections.
+
+**1yr event recall across 6 profiles (NIP-66 liveness filter):**
+
+| Profile | Follows | Voyage (5-13 relays) | Greedy @20 | Welshman @20 | Nostur @20 |
+|---------|--------:|---------------------:|-----------:|-------------:|-----------:|
+| fiatjaf | 194 | 6.4% | 28.8% | 32.8% | 27.3% |
+| hodlbod | 452 | 12.9% | 16.7% | 48.5% | 33.8% |
+| Kieran | 377 | 4.2% | 8.7% | 15.2% | 18.9% |
+| jb55 | 908 | 8.7% | 17.1% | 27.8% | 23.4% |
+| ODELL | 1,779 | 6.4% | 10.8% | 16.8% | 23.3% |
+| Derek Ross | 1,330 | 9.8% | 18.6% | 26.7% | 26.3% |
+| **Mean** | | **8.1%** | **16.8%** | **28.0%** | **25.5%** |
+
+Voyage uses roughly half the relay budget of other algorithms and gets roughly half the recall. The connection budget is not the constraint — the algorithm itself saturates early.
+
+### The Latency-Coverage Tradeoff
+
+Fewer relays means faster time-to-first-event (TTFE) but lower recall. The benchmark data reveals this tension clearly:
+
+| Algorithm | Relays (fiatjaf) | 1yr Recall | TTFE | Progressive @2s |
+|-----------|--:|-------:|------:|------:|
+| Voyage | 8 | 6.4% | 608ms | 62.7% |
+| Greedy @20 | 20 | 28.8% | 608ms | 22.0% |
+| Welshman @20 | 20 | 32.8% | 608ms | 21.0% |
+
+Voyage achieves the **best progressive completeness at 2s** (62.7% of its eventual recall) because fewer relays means less waiting. But its eventual recall ceiling is so low (6.4%) that 62.7% of 6.4% is worse than 22.0% of 28.8% in absolute terms.
+
+This is a fundamental tradeoff: connecting to more relays increases recall but adds latency from slow/dead relays. The NIP-66 liveness filter helps by removing dead relays, but the optimal balance depends on the use case:
+
+- **Feed load (background sync):** Maximize recall — the user won't notice a few extra seconds of relay negotiation
+- **Interactive navigation (tap on profile):** Minimize TTFE — connect to 2-3 relays, accept lower recall
+- **Hybrid:** Use more connections for feed, fewer for profile views
+
+No client currently adapts its connection budget per use case. Voyage's low connection count is better suited for interactive profile views than feed loading.
+
 ## Client Mapping
 
 | Client | Benchmark proxy | Gap vs best |
@@ -65,6 +103,7 @@ Direct Mapping                 | 69.1% | 69.6% | 71.6% | 71.6% | 71.6% | 72.7% |
 | Amethyst | direct-mapping | ~3-5% |
 | rust-nostr clients | filter-decomposition | ~3-5% |
 | Nostur | greedy-coverage-sort | ~5-12% |
+| Voyage | voyage-multiphase | ~8-25% |
 
 ## Methodology
 

--- a/bench/phase-1-findings.md
+++ b/bench/phase-1-findings.md
@@ -1,6 +1,6 @@
 # On-Paper Relay Mapping: Algorithm Comparison
 
-6 relay selection strategies benchmarked against identical real-world NIP-65 data across 11 profiles.
+7 relay selection strategies benchmarked against real-world NIP-65 data. The original 6 algorithms were tested across 11 profiles for assignment coverage; Voyage was added later and tested across 6 profiles for 1yr event recall.
 
 ## Results
 
@@ -57,7 +57,7 @@ Direct Mapping                 | 69.1% | 69.6% | 71.6% | 71.6% | 71.6% | 72.7% |
 
 ### Voyage: Connection Budget vs 1yr Event Recall
 
-Voyage's multi-phase algorithm uses `pubkeyCache` deduplication in Phase 1 — each pubkey is assigned to exactly 1 relay before moving on. This means the top 5-13 relays absorb all follows, and the 25-connection budget goes mostly unused. The redundancy pass (Phase 4) adds second-relay coverage within those same relays but never opens new connections.
+Voyage's multi-phase algorithm uses `pubkeyCache` deduplication in Phase 1 — each pubkey is assigned to exactly 1 relay before moving on. This means the top 5-13 relays absorb all follows, and the 25-connection budget goes mostly unused. The redundancy pass (Phase 4) adds additional relay coverage within those same relays but never opens new connections.
 
 **1yr event recall across 6 profiles (NIP-66 liveness filter):**
 
@@ -73,11 +73,11 @@ Follow counts below reflect the contact-list snapshot at benchmark time (March 2
 | Derek Ross | 1,330 | 9.8% | 18.6% | 26.7% | 26.3% |
 | **Mean** | | **8.1%** | **16.8%** | **28.0%** | **25.5%** |
 
-Voyage uses roughly half the relay budget of other algorithms and gets roughly half the recall. The connection budget is not the constraint — the algorithm itself saturates early.
+Voyage uses 5-13 relays vs 20 for other algorithms and gets roughly half the recall of greedy (8.1% vs 16.8%) and under a third of Welshman (28.0%). The connection budget is not the constraint — the algorithm itself saturates early.
 
 ### The Latency-Coverage Tradeoff
 
-Fewer relays means faster time-to-first-event (TTFE) but lower recall. The benchmark data reveals this tension clearly:
+Fewer relays means faster convergence to full recall but a lower recall ceiling. TTFE (time-to-first-event) depends on the fastest relay in the set, not the number of relays — so TTFE can be identical across algorithms. The real difference shows up in progressive completeness: what fraction of the algorithm's eventual recall is achieved by a given time.
 
 | Algorithm | Relays (fiatjaf) | 1yr Recall | TTFE | Progressive @2s |
 |-----------|--:|-------:|------:|------:|
@@ -85,7 +85,7 @@ Fewer relays means faster time-to-first-event (TTFE) but lower recall. The bench
 | Greedy @20 | 20 | 28.8% | 608ms | 22.0% |
 | Welshman @20 | 20 | 32.8% | 608ms | 21.0% |
 
-Voyage achieves the **best progressive completeness at 2s** (62.7% of its eventual recall) because fewer relays means less waiting. But its eventual recall ceiling is so low (6.4%) that 62.7% of 6.4% is worse than 22.0% of 28.8% in absolute terms.
+Voyage achieves the **best progressive completeness at 2s** (62.7% of its eventual recall) because fewer relays finish sooner. But its eventual recall ceiling is so low (6.4%) that 62.7% of 6.4% = 4.0% absolute recall is worse than 22.0% of 28.8% = 6.3% absolute recall for greedy.
 
 This is a fundamental tradeoff: connecting to more relays increases recall but adds latency from slow/dead relays. The NIP-66 liveness filter helps by removing dead relays, but the optimal balance depends on the use case:
 
@@ -97,7 +97,7 @@ None of the benchmarked clients in this study (as of March 2026) adapt their con
 
 ## Client Mapping
 
-| Client | Benchmark proxy | Gap vs best |
+| Client | Benchmark proxy | Assignment gap vs best |
 |--------|----------------|-------------|
 | Gossip | greedy-set-cover | -- (winner) |
 | NDK (noStrudel) | priority-based | ~0-1% |
@@ -105,11 +105,13 @@ None of the benchmarked clients in this study (as of March 2026) adapt their con
 | Amethyst | direct-mapping | ~3-5% |
 | rust-nostr clients | filter-decomposition | ~3-5% |
 | Nostur | greedy-coverage-sort | ~5-12% |
-| Voyage | voyage-multiphase | ~8-25% |
+| Voyage | voyage-multiphase | ~0%* |
+
+*Voyage matches greedy on assignment coverage (both hit the NIP-65 ceiling) but uses far fewer relays (5-13 vs 20). The gap appears in 1yr event recall: ~8% mean vs greedy's ~17% (see Voyage section above).
 
 ## Methodology
 
-- 6 algorithms, all capped at 20 WebSocket connections
+- 7 algorithms, capped at 20 WebSocket connections (Voyage: 25 native cap)
 - Relay lists from purplepag.es, relay.damus.io, nos.lol
 - Strict filtering: no localhost, IP-only, ws://, known aggregators
 - Deterministic tie-breaking, seedable PRNG (seed=0)

--- a/bench/src/algorithms/mod.ts
+++ b/bench/src/algorithms/mod.ts
@@ -34,6 +34,7 @@ import { bigRelaysBaseline } from "./big-relays.ts";
 import { fdThompson } from "./fd-thompson.ts";
 import { dittoMew } from "./ditto-mew.ts";
 import { dittoOutbox } from "./ditto-outbox.ts";
+import { voyageMultiphase } from "./voyage-multiphase.ts";
 
 export interface AlgorithmEntry {
   id: string;
@@ -239,6 +240,14 @@ export const ALGORITHM_REGISTRY: AlgorithmEntry[] = [
     nativeCap: false,
     stochastic: true,
     defaults: { writeLimit: 3 },
+  },
+  {
+    id: "voyage",
+    name: "Voyage Multi-Phase",
+    fn: voyageMultiphase,
+    nativeCap: true,
+    stochastic: false,
+    defaults: { maxConnections: 25, maxRelaysPerUser: 2 },
   },
 ];
 

--- a/bench/src/algorithms/voyage-multiphase.ts
+++ b/bench/src/algorithms/voyage-multiphase.ts
@@ -23,9 +23,9 @@ import type {
  * Phase 3 (orphan distribution): Pubkeys not yet assigned get distributed
  *   across already-selected relays from Phase 1.
  *
- * Phase 4 (redundancy pass): Pubkeys mapped to only 1 relay get added to
- *   additional already-selected relays (ensures ≥2 relays per pubkey where
- *   possible).
+ * Phase 4 (redundancy pass): Pubkeys mapped to fewer than maxRelaysPerUser
+ *   relays get added to additional already-selected relays (ensures
+ *   ≥maxRelaysPerUser relays per pubkey where possible).
  *
  * Deterministic: replaces Voyage's takeRandom()/shuffled() with sorted-by-hex.
  * MAX_KEYS=750 never binds at profile sizes ≤2,784.
@@ -107,7 +107,8 @@ export function voyageMultiphase(
     }
   }
 
-  // ── Phase 4: Redundancy pass (ensure ≥2 relays per pubkey) ────────
+  // ── Phase 4: Redundancy pass (ensure ≥maxRelaysPerUser relays per pubkey) ──
+  // Voyage's upstream hardcodes == 1, but we generalize to honor maxRelaysPerUser.
   // Build a temporary pubkey→relayCount map from current result
   const pubkeyRelayCount = new Map<Pubkey, number>();
   for (const [, pubkeys] of result) {
@@ -116,30 +117,35 @@ export function voyageMultiphase(
     }
   }
 
-  const singleCoveredPubkeys = new Set<Pubkey>(
+  const underCoveredPubkeys = new Set<Pubkey>(
     [...pubkeyRelayCount.entries()]
-      .filter(([, count]) => count === 1)
+      .filter(([, count]) => count < _maxRelaysPerUser)
       .map(([pk]) => pk),
   );
 
-  if (singleCoveredPubkeys.size > 0) {
+  if (underCoveredPubkeys.size > 0) {
     // Deterministic: iterate selected relays sorted by URL
     const relayKeys = [...result.keys()].sort();
     for (const relay of relayKeys) {
-      if (singleCoveredPubkeys.size === 0) break;
+      if (underCoveredPubkeys.size === 0) break;
       const selectedPubkeys = result.get(relay)!;
       const maxKeys = MAX_KEYS - selectedPubkeys.size;
       if (maxKeys <= 0) continue;
 
-      // Add single-covered pubkeys not already on this relay
-      const addable = [...singleCoveredPubkeys]
+      // Add under-covered pubkeys not already on this relay
+      const addable = [...underCoveredPubkeys]
         .filter((pk) => !selectedPubkeys.has(pk))
         .sort()
         .slice(0, maxKeys);
 
       for (const pk of addable) {
         selectedPubkeys.add(pk);
-        singleCoveredPubkeys.delete(pk);
+        // Recount: if this pubkey now has enough relays, remove from set
+        const newCount = (pubkeyRelayCount.get(pk) ?? 0) + 1;
+        pubkeyRelayCount.set(pk, newCount);
+        if (newCount >= _maxRelaysPerUser) {
+          underCoveredPubkeys.delete(pk);
+        }
       }
     }
   }
@@ -174,7 +180,7 @@ export function voyageMultiphase(
       `Phase 1: top ${maxConnections} relays by coverage (deterministic)`,
       "Phase 2: skipped (no event history in static benchmark)",
       "Phase 3: orphans distributed to selected relays",
-      "Phase 4: redundancy pass (single-covered → ≥2 relays)",
+      `Phase 4: redundancy pass (under-covered → ≥${_maxRelaysPerUser} relays)`,
     ],
   };
 }

--- a/bench/src/algorithms/voyage-multiphase.ts
+++ b/bench/src/algorithms/voyage-multiphase.ts
@@ -1,0 +1,180 @@
+import type {
+  AlgorithmResult,
+  AlgorithmParams,
+  BenchmarkInput,
+  Pubkey,
+  RelayUrl,
+} from "../types.ts";
+
+/**
+ * Voyage Multi-Phase (deterministic benchmark port)
+ *
+ * Faithful port of Voyage's RelayProvider.getObserveRelays() with
+ * benchmark-appropriate adaptations:
+ *
+ * Phase 1 (NIP-65 sort-and-take): Group relayToWriters by relay, sort by
+ *   coverage count descending (tie-break: URL ascending). Take top
+ *   maxConnections relays. Assign each pubkey to exactly 1 relay via
+ *   pubkeyCache tracking. Cap at MAX_KEYS (750) pubkeys per relay.
+ *
+ * Phase 2 (event history): SKIPPED — runtime learning data unavailable
+ *   in static benchmark.
+ *
+ * Phase 3 (orphan distribution): Pubkeys not yet assigned get distributed
+ *   across already-selected relays from Phase 1.
+ *
+ * Phase 4 (redundancy pass): Pubkeys mapped to only 1 relay get added to
+ *   additional already-selected relays (ensures ≥2 relays per pubkey where
+ *   possible).
+ *
+ * Deterministic: replaces Voyage's takeRandom()/shuffled() with sorted-by-hex.
+ * MAX_KEYS=750 never binds at profile sizes ≤2,784.
+ *
+ * Defaults: maxConnections=25 (MAX_AUTOPILOT_RELAYS), maxRelaysPerUser=2.
+ */
+
+const MAX_KEYS = 750;
+
+export function voyageMultiphase(
+  input: BenchmarkInput,
+  params: AlgorithmParams,
+  _rng: () => number,
+): AlgorithmResult {
+  const start = performance.now();
+  const maxConnections = params.maxConnections ?? 25;
+  const _maxRelaysPerUser = params.maxRelaysPerUser ?? 2;
+
+  const result = new Map<RelayUrl, Set<Pubkey>>();
+  const followsSet = new Set(input.follows);
+
+  // ── Phase 1: Cover pubkey-write-relay pairing ──────────────────────
+  // Sort relays by coverage count descending, tie-break URL ascending.
+  // In the live app, secondary sorts are by eventRelays membership,
+  // connection status, and disconnected status — none available in a
+  // static benchmark, so coverage-count sort is the sole criterion
+  // (same degeneration as Nostur without skipTopRelays).
+  const pubkeyCache = new Set<Pubkey>();
+
+  const sortedRelays = [...input.relayToWriters.entries()]
+    .sort((a, b) => {
+      if (a[1].size !== b[1].size) return b[1].size - a[1].size;
+      return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
+    });
+
+  const selectedRelays = sortedRelays.slice(0, maxConnections);
+
+  for (const [relay, writers] of selectedRelays) {
+    const currentSize = result.get(relay)?.size ?? 0;
+    const maxToAdd = Math.max(0, MAX_KEYS - currentSize);
+
+    // Deterministic: filter to uncached follows, sort by hex
+    const newPubkeys = [...writers]
+      .filter((pk) => followsSet.has(pk) && !pubkeyCache.has(pk))
+      .sort()
+      .slice(0, maxToAdd);
+
+    if (newPubkeys.length > 0) {
+      result.set(relay, new Set(newPubkeys));
+      for (const pk of newPubkeys) pubkeyCache.add(pk);
+    }
+  }
+
+  // ── Phase 2: Event history — SKIPPED (no runtime data) ────────────
+
+  // ── Phase 3: Distribute orphans across already-selected relays ────
+  const restPubkeys = input.follows.filter(
+    (pk) => !pubkeyCache.has(pk) && input.writerToRelays.has(pk),
+  );
+
+  if (restPubkeys.length > 0) {
+    // Deterministic order: iterate selected relay keys sorted by URL
+    const relayKeys = [...result.keys()].sort();
+    for (const relay of relayKeys) {
+      const present = result.get(relay)!;
+      const maxKeys = MAX_KEYS - present.size;
+      if (maxKeys <= 0) continue;
+
+      // Deterministic: sort orphans by hex, take up to maxKeys
+      const addable = restPubkeys
+        .filter((pk) => !pubkeyCache.has(pk))
+        .sort()
+        .slice(0, maxKeys);
+
+      for (const pk of addable) {
+        present.add(pk);
+        pubkeyCache.add(pk);
+      }
+    }
+  }
+
+  // ── Phase 4: Redundancy pass (ensure ≥2 relays per pubkey) ────────
+  // Build a temporary pubkey→relayCount map from current result
+  const pubkeyRelayCount = new Map<Pubkey, number>();
+  for (const [, pubkeys] of result) {
+    for (const pk of pubkeys) {
+      pubkeyRelayCount.set(pk, (pubkeyRelayCount.get(pk) ?? 0) + 1);
+    }
+  }
+
+  const singleCoveredPubkeys = new Set<Pubkey>(
+    [...pubkeyRelayCount.entries()]
+      .filter(([, count]) => count === 1)
+      .map(([pk]) => pk),
+  );
+
+  if (singleCoveredPubkeys.size > 0) {
+    // Deterministic: iterate selected relays sorted by URL
+    const relayKeys = [...result.keys()].sort();
+    for (const relay of relayKeys) {
+      if (singleCoveredPubkeys.size === 0) break;
+      const selectedPubkeys = result.get(relay)!;
+      const maxKeys = MAX_KEYS - selectedPubkeys.size;
+      if (maxKeys <= 0) continue;
+
+      // Add single-covered pubkeys not already on this relay
+      const addable = [...singleCoveredPubkeys]
+        .filter((pk) => !selectedPubkeys.has(pk))
+        .sort()
+        .slice(0, maxKeys);
+
+      for (const pk of addable) {
+        selectedPubkeys.add(pk);
+        singleCoveredPubkeys.delete(pk);
+      }
+    }
+  }
+
+  // ── Build output structures ────────────────────────────────────────
+  const relayAssignments = new Map<RelayUrl, Set<Pubkey>>();
+  const pubkeyAssignments = new Map<Pubkey, Set<RelayUrl>>();
+
+  for (const [relay, pubkeys] of result) {
+    if (pubkeys.size === 0) continue;
+    relayAssignments.set(relay, pubkeys);
+    for (const pk of pubkeys) {
+      const existing = pubkeyAssignments.get(pk) ?? new Set<RelayUrl>();
+      existing.add(relay);
+      pubkeyAssignments.set(pk, existing);
+    }
+  }
+
+  const orphanedPubkeys = new Set<Pubkey>();
+  for (const pk of input.follows) {
+    if (!pubkeyAssignments.has(pk)) orphanedPubkeys.add(pk);
+  }
+
+  return {
+    name: "Voyage Multi-Phase",
+    relayAssignments,
+    pubkeyAssignments,
+    orphanedPubkeys,
+    params,
+    executionTimeMs: performance.now() - start,
+    notes: [
+      `Phase 1: top ${maxConnections} relays by coverage (deterministic)`,
+      "Phase 2: skipped (no event history in static benchmark)",
+      "Phase 3: orphans distributed to selected relays",
+      "Phase 4: redundancy pass (single-covered → ≥2 relays)",
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

- Faithful port of Voyage's `RelayProvider.getObserveRelays()` for static benchmarking
- Phase 1: NIP-65 coverage-count sort, take top `maxConnections` (25) relays
- Phase 2: Skipped (event history unavailable in static benchmark)
- Phase 3: Distribute orphans across already-selected relays
- Phase 4: Redundancy pass — ensure ≥`maxRelaysPerUser` relays per pubkey
- Deterministic (`sorted-by-hex` replaces `takeRandom`/`shuffled`)

## 1yr Event Recall Results (6 profiles, NIP-66 liveness filter)

| Profile | Follows | Voyage (5-13 relays) | Greedy @20 | Welshman @20 | Nostur @20 |
|---|---|---|---|---|---|
| fiatjaf | 194 | 6.4% | 28.8% | 32.8% | 27.3% |
| hodlbod | 452 | 12.9% | 16.7% | 48.5% | 33.8% |
| Kieran | 377 | 4.2% | 8.7% | 15.2% | 18.9% |
| jb55 | 908 | 8.7% | 17.1% | 27.8% | 23.4% |
| ODELL | 1,779 | 6.4% | 10.8% | 16.8% | 23.3% |
| Derek Ross | 1,330 | 9.8% | 18.6% | 26.7% | 26.3% |
| **Mean** | | **8.1%** | **16.8%** | **28.0%** | **25.5%** |

**Root cause of low recall:** `pubkeyCache` deduplication assigns each pubkey to only 1 relay in Phase 1, so the top 5–13 relays absorb all follows. The 25-connection budget goes mostly unused — the algorithm naturally saturates at 5–13 relays. The redundancy pass (Phase 4) adds additional relay coverage within those same relays but never opens new connections.

**On assignment coverage**, Voyage matches greedy (~0% gap) because both hit the NIP-65 ceiling. The gap only appears in event recall.

## Latency-Coverage Tradeoff

TTFE (time-to-first-event) depends on the fastest relay in the set, not the number of relays — all three algorithms show identical 608ms TTFE for fiatjaf. The real difference is progressive completeness: Voyage reaches 62.7% of its eventual recall within 2s (vs 22% for greedy), because fewer relays finish sooner. But in absolute terms, 62.7% × 6.4% = 4.0% is worse than 22.0% × 28.8% = 6.3%.

## Files changed

- `bench/src/algorithms/voyage-multiphase.ts` — **NEW** algorithm implementation
- `bench/src/algorithms/mod.ts` — import + registry entry (`id: "voyage"`, `nativeCap: true`, `stochastic: false`)
- `bench/phase-1-findings.md` — results table, latency-coverage analysis, client mapping update

## Test plan

- [x] Smoke test: compiles and runs with `--algorithms voyage,greedy,nostur`
- [x] 1yr event recall verified across 6 diverse profiles (fiatjaf, hodlbod, Kieran, jb55, ODELL, Derek Ross)
- [x] `maxConnections=20` isolation confirms algorithm saturates at 5–13 relays regardless of budget
- [x] Phase 4 generalized to honor `maxRelaysPerUser` (backward-compatible: default=2 gives identical results)
- [x] All numbers in docs cross-checked against JSON result files

🤖 Generated with [Claude Code](https://claude.com/claude-code)