### PR TITLE
Add configurable Thompson decay rate

### DIFF
--- a/bench/main.ts
+++ b/bench/main.ts
@@ -41,6 +41,8 @@ import type {
   AlgorithmResult,
   BenchmarkInput,
   CliOptions,
+  DecayConfig,
+  DecayUnit,
   FilterProfile,
   Nip66RelayData,
   Phase2Result,
@@ -78,6 +80,8 @@ Options:
   --enrich-hints            Enrich relay sets with p-tag relay hints from kind-1 events
   --nip66-filter <mode>     NIP-66 liveness filter: liveness (default), strict
   --nip66-ttl <ms>          NIP-66 cache TTL override in ms
+  --decay-factor <n>        Thompson decay factor (default: 0.95)
+  --decay-unit <unit>       Decay unit: session (default) or hour
   --no-cache                Skip cache
   --no-phase2-cache         Skip Phase 2 baseline disk cache
   --verbose                 Per-relay details, raw vs post-processed metrics
@@ -102,6 +106,8 @@ function parseCliOptions(): CliOptions {
       "verify-concurrency",
       "nip66-filter",
       "nip66-ttl",
+      "decay-factor",
+      "decay-unit",
     ],
     boolean: ["sweep", "fast", "full-assignments", "no-cache", "no-phase2-cache", "verbose", "verify", "enrich-hints", "help"],
     default: {
@@ -164,6 +170,8 @@ function parseCliOptions(): CliOptions {
     verifyConcurrency: parseInt(args["verify-concurrency"]!, 10),
     nip66Filter: parseNip66FilterArg(args["nip66-filter"]),
     nip66TtlMs: args["nip66-ttl"] ? parseInt(args["nip66-ttl"], 10) : undefined,
+    decayFactor: args["decay-factor"] ? parseFloat(args["decay-factor"]) : undefined,
+    decayUnit: args["decay-unit"] as DecayUnit | undefined,
   };
 }
 
@@ -487,6 +495,10 @@ async function runDefault(
 
     // Thompson Sampling learning: update relay scores from Phase 2 results (per-algorithm)
     if (hasThompson && phase2Result._baselines && phase2Result._cache) {
+      const decayConfig: DecayConfig | undefined = opts.decayFactor !== undefined || opts.decayUnit !== undefined
+        ? { factor: opts.decayFactor ?? 0.95, unit: opts.decayUnit ?? "session" }
+        : undefined;
+
       for (let i = 0; i < algorithms.length; i++) {
         const entry = algorithms[i];
         if (!THOMPSON_IDS.has(entry.id)) continue;
@@ -506,6 +518,7 @@ async function runDefault(
             phase2Result._cache as QueryCache,
             phase2Result._relayOutcomes,
             input.writerToRelays,
+            decayConfig,
           );
         } else {
           db = updateRelayScores(
@@ -516,7 +529,13 @@ async function runDefault(
             phase2Result._baselines,
             phase2Result._cache as QueryCache,
             phase2Result._relayOutcomes,
+            undefined,
+            decayConfig,
           );
+        }
+        if (decayConfig) {
+          db.decayFactor = decayConfig.factor;
+          db.decayUnit = decayConfig.unit;
         }
         thompsonDBs.set(entry.id, db);
         await saveRelayScores(db, opts.nip66Filter || undefined, entry.id);

--- a/bench/src/relay-scores.ts
+++ b/bench/src/relay-scores.ts
@@ -7,6 +7,7 @@
  */
 
 import type {
+  DecayConfig,
   PubkeyBaseline,
   Pubkey,
   RelayUrl,
@@ -17,9 +18,23 @@ import type { QueryCache, RelayOutcome } from "./relay-pool.ts";
 
 const CACHE_DIR = ".cache";
 const SCHEMA_VERSION = 1;
-const DECAY_FACTOR = 0.95; // exponential decay per session
+const DEFAULT_DECAY_FACTOR = 0.95; // exponential decay per session
 const MAX_SESSION_HISTORY = 10; // keep last N session rates for trend
 const TREND_MIN_SESSIONS = 3; // minimum sessions before computing trend
+
+/** Compute effective decay multiplier based on config.
+ *  "session" unit: factor^1 per call (unchanged from original).
+ *  "hour" unit: factor^(elapsed_hours) since last update.   */
+function computeDecay(db: RelayScoreDB, config?: DecayConfig): number {
+  const factor = config?.factor ?? DEFAULT_DECAY_FACTOR;
+  if (!config || config.unit === "session") {
+    return factor;
+  }
+  // hour-based: compute elapsed hours since last session
+  const elapsedMs = Date.now() - db.updatedAt;
+  const elapsedHours = Math.max(elapsedMs / 3_600_000, 0);
+  return Math.pow(factor, elapsedHours);
+}
 
 /** Minimum beta dampening factor for coverage-weighted scoring.
  *  Lower = more protection for sole-source relays (0 = no penalty, 1 = full penalty). */
@@ -79,11 +94,13 @@ export function updateRelayScores(
   cache: QueryCache,
   relayOutcomes?: ReadonlyMap<RelayUrl, RelayOutcome>,
   _writerToRelays?: ReadonlyMap<Pubkey, Set<RelayUrl>>,
+  decayConfig?: DecayConfig,
 ): RelayScoreDB {
   // Apply decay to existing scores
+  const decay = computeDecay(db, decayConfig);
   for (const entry of Object.values(db.relays)) {
-    entry.alpha = 1 + (entry.alpha - 1) * DECAY_FACTOR;
-    entry.beta = 1 + (entry.beta - 1) * DECAY_FACTOR;
+    entry.alpha = 1 + (entry.alpha - 1) * decay;
+    entry.beta = 1 + (entry.beta - 1) * decay;
   }
 
   // Compute new observations from this session
@@ -187,11 +204,13 @@ export function updateRelayScoresCW(
   cache: QueryCache,
   relayOutcomes?: ReadonlyMap<RelayUrl, RelayOutcome>,
   _writerToRelays?: ReadonlyMap<Pubkey, Set<RelayUrl>>,
+  decayConfig?: DecayConfig,
 ): RelayScoreDB {
   // Apply decay to existing scores
+  const decay = computeDecay(db, decayConfig);
   for (const entry of Object.values(db.relays)) {
-    entry.alpha = 1 + (entry.alpha - 1) * DECAY_FACTOR;
-    entry.beta = 1 + (entry.beta - 1) * DECAY_FACTOR;
+    entry.alpha = 1 + (entry.alpha - 1) * decay;
+    entry.beta = 1 + (entry.beta - 1) * decay;
   }
 
   // Compute new observations from this session
@@ -309,11 +328,13 @@ export function updateRelayScoresSE(
   cache: QueryCache,
   relayOutcomes?: ReadonlyMap<RelayUrl, RelayOutcome>,
   writerToRelays?: ReadonlyMap<Pubkey, Set<RelayUrl>>,
+  decayConfig?: DecayConfig,
 ): RelayScoreDB {
   // Apply decay to existing scores
+  const decay = computeDecay(db, decayConfig);
   for (const entry of Object.values(db.relays)) {
-    entry.alpha = 1 + (entry.alpha - 1) * DECAY_FACTOR;
-    entry.beta = 1 + (entry.beta - 1) * DECAY_FACTOR;
+    entry.alpha = 1 + (entry.alpha - 1) * decay;
+    entry.beta = 1 + (entry.beta - 1) * decay;
   }
 
   // Compute new observations from this session
@@ -481,13 +502,15 @@ export function updateRelayScoresPW(
   cache: QueryCache,
   relayOutcomes?: ReadonlyMap<RelayUrl, RelayOutcome>,
   writerToRelays?: ReadonlyMap<Pubkey, Set<RelayUrl>>,
+  decayConfig?: DecayConfig,
 ): RelayScoreDB {
   const SOLE_SOURCE_WEIGHT = 0.3;
 
   // Apply decay to existing scores
+  const decay = computeDecay(db, decayConfig);
   for (const entry of Object.values(db.relays)) {
-    entry.alpha = 1 + (entry.alpha - 1) * DECAY_FACTOR;
-    entry.beta = 1 + (entry.beta - 1) * DECAY_FACTOR;
+    entry.alpha = 1 + (entry.alpha - 1) * decay;
+    entry.beta = 1 + (entry.beta - 1) * decay;
   }
 
   // Compute new observations from this session

--- a/bench/src/types.ts
+++ b/bench/src/types.ts
@@ -159,6 +159,8 @@ export interface CliOptions {
   nip66TtlMs?: number;
   noPhase2Cache: boolean;
   enrichHints: boolean;
+  decayFactor?: number;
+  decayUnit?: DecayUnit;
 }
 
 export interface SerializedAlgorithmResult {
@@ -510,6 +512,15 @@ export interface Nip66RelayDataSerialized {
   monitorPubkey: string;
 }
 
+// --- Decay configuration ---
+
+export type DecayUnit = "session" | "hour";
+
+export interface DecayConfig {
+  factor: number;
+  unit: DecayUnit;
+}
+
 // --- Relay Score DB (Thompson Sampling persistence) ---
 
 export interface RelayScoreEntry {
@@ -535,4 +546,7 @@ export interface RelayScoreDB {
   updatedAt: number;
   sessionCount: number;
   relays: Record<RelayUrl, RelayScoreEntry>;
+  /** Decay configuration used for this score file. */
+  decayFactor?: number;
+  decayUnit?: DecayUnit;
 }


### PR DESCRIPTION
## Summary
- Add `--decay-factor` and `--decay-unit` CLI flags for configurable Thompson prior decay
- Supports two decay units: `session` (default, current behavior) and `hour` (welshman-style)
- Default behavior with no flags is identical to before: 0.95 per session

## Motivation
Welshman PR #53 uses 0.95/hour exponential decay, but the benchmark tool hardcodes 0.95/session — a completely different unit. This makes it impossible to compare the two decay strategies. With this PR, benchmarks can run:

```bash
# Current default (no change)
deno task bench <pk> --algorithms welshman-thompson --verify ...

# Welshman-style hourly decay
deno task bench <pk> --algorithms welshman-thompson --decay-factor 0.95 --decay-unit hour --verify ...

# Aggressive session decay
deno task bench <pk> --algorithms welshman-thompson --decay-factor 0.90 --verify ...
```

## Changes
| File | Change |
|------|--------|
| `bench/src/types.ts` | Add `DecayConfig`, `DecayUnit` types; optional decay fields on `RelayScoreDB` |
| `bench/src/relay-scores.ts` | `computeDecay()` function; all 4 scoring variants accept `DecayConfig` |
| `bench/main.ts` | Parse `--decay-factor` / `--decay-unit`; thread to scoring; store in DB |

## Backward compatibility
- No flags → `0.95/session` (identical to before)
- Existing 227 score files load without errors (new fields are optional)
- `deno check main.ts` passes clean

## Benchmark plan (not in this PR)
After this lands, run welshman-thompson at 1yr, 6 EN profiles, 5 sessions, NIP-66, cap@20:
- No decay (control)
- 0.95/session (current default)
- 0.95/hour (welshman-style)
- 0.90/session (aggressive)

Resolves outbox-ojy (infrastructure only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)